### PR TITLE
Investigate elide lifetimes

### DIFF
--- a/src/cmd/le.rs
+++ b/src/cmd/le.rs
@@ -1165,7 +1165,7 @@ pub struct LeSetPeriodicAdvSubeventDataParams<'a, 'b> {
     pub subevent: &'b [LePeriodicAdvSubeventData<'a>],
 }
 
-impl<'a, 'b> WriteHci for LeSetPeriodicAdvSubeventDataParams<'a, 'b> {
+impl WriteHci for LeSetPeriodicAdvSubeventDataParams<'_, '_> {
     #[inline(always)]
     fn size(&self) -> usize {
         self.adv_handle.size() + self.subevent.size()

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,15 +1,7 @@
 //! HCI data packets [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-c8fdfc58-ec59-1a87-6e78-0a01de2e0846)
 
-use crate::param::{ param, ConnHandle };
-use crate::{
-    FromHciBytes,
-    FromHciBytesError,
-    HostToControllerPacket,
-    PacketKind,
-    ReadHci,
-    ReadHciError,
-    WriteHci,
-};
+use crate::param::{param, ConnHandle};
+use crate::{FromHciBytes, FromHciBytesError, HostToControllerPacket, PacketKind, ReadHci, ReadHciError, WriteHci};
 
 /// HCI ACL Data packet `Packet_Boundary_Flag` [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-49cf6aaa-b2f3-30b0-e737-5b515d3b3168)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -92,12 +84,7 @@ pub struct AclPacket<'a> {
 
 impl<'a> AclPacket<'a> {
     /// Create a new instance.
-    pub fn new(
-        handle: ConnHandle,
-        pbf: AclPacketBoundary,
-        bf: AclBroadcastFlag,
-        data: &'a [u8]
-    ) -> Self {
+    pub fn new(handle: ConnHandle, pbf: AclPacketBoundary, bf: AclBroadcastFlag, data: &'a [u8]) -> Self {
         let handle: u16 = handle.into_inner() | ((pbf as u16) << 12) | ((bf as u16) << 14);
         Self { handle, data }
     }
@@ -105,7 +92,7 @@ impl<'a> AclPacket<'a> {
     /// Create an `AclPacket` from `header` and `data`
     pub fn from_header_hci_bytes(
         header: AclPacketHeader,
-        data: &'a [u8]
+        data: &'a [u8],
     ) -> Result<(Self, &'a [u8]), FromHciBytesError> {
         let data_len = usize::from(header.data_len);
         if data.len() < data_len {
@@ -165,10 +152,7 @@ impl<'de> FromHciBytes<'de> for AclPacket<'de> {
 impl<'de> ReadHci<'de> for AclPacket<'de> {
     const MAX_LEN: usize = 255;
 
-    fn read_hci<R: embedded_io::Read>(
-        mut reader: R,
-        buf: &'de mut [u8]
-    ) -> Result<Self, ReadHciError<R::Error>> {
+    fn read_hci<R: embedded_io::Read>(mut reader: R, buf: &'de mut [u8]) -> Result<Self, ReadHciError<R::Error>> {
         let mut header = [0; 4];
         reader.read_exact(&mut header)?;
         let (header, _) = AclPacketHeader::from_hci_bytes(&header)?;
@@ -185,7 +169,7 @@ impl<'de> ReadHci<'de> for AclPacket<'de> {
 
     async fn read_hci_async<R: embedded_io_async::Read>(
         mut reader: R,
-        buf: &'de mut [u8]
+        buf: &'de mut [u8],
     ) -> Result<Self, ReadHciError<R::Error>> {
         let mut header = [0; 4];
         reader.read_exact(&mut header).await?;
@@ -219,10 +203,7 @@ impl WriteHci for AclPacket<'_> {
     }
 
     #[inline(always)]
-    async fn write_hci_async<W: embedded_io_async::Write>(
-        &self,
-        mut writer: W
-    ) -> Result<(), W::Error> {
+    async fn write_hci_async<W: embedded_io_async::Write>(&self, mut writer: W) -> Result<(), W::Error> {
         let header = AclPacketHeader {
             handle: self.handle,
             data_len: self.data.len() as u16,
@@ -300,7 +281,7 @@ impl<'a> SyncPacket<'a> {
     /// Create a `SyncPacket` from `header` and `data`
     pub fn from_header_hci_bytes(
         header: SyncPacketHeader,
-        data: &'a [u8]
+        data: &'a [u8],
     ) -> Result<(Self, &'a [u8]), FromHciBytesError> {
         let data_len = usize::from(header.data_len);
         if data.len() < data_len {
@@ -349,10 +330,7 @@ impl<'de> FromHciBytes<'de> for SyncPacket<'de> {
 impl<'de> ReadHci<'de> for SyncPacket<'de> {
     const MAX_LEN: usize = 258;
 
-    fn read_hci<R: embedded_io::Read>(
-        mut reader: R,
-        buf: &'de mut [u8]
-    ) -> Result<Self, ReadHciError<R::Error>> {
+    fn read_hci<R: embedded_io::Read>(mut reader: R, buf: &'de mut [u8]) -> Result<Self, ReadHciError<R::Error>> {
         let mut header = [0; 3];
         reader.read_exact(&mut header)?;
         let (header, _) = SyncPacketHeader::from_hci_bytes(&header)?;
@@ -369,7 +347,7 @@ impl<'de> ReadHci<'de> for SyncPacket<'de> {
 
     async fn read_hci_async<R: embedded_io_async::Read>(
         mut reader: R,
-        buf: &'de mut [u8]
+        buf: &'de mut [u8],
     ) -> Result<Self, ReadHciError<R::Error>> {
         let mut header = [0; 3];
         reader.read_exact(&mut header).await?;
@@ -403,10 +381,7 @@ impl WriteHci for SyncPacket<'_> {
     }
 
     #[inline(always)]
-    async fn write_hci_async<W: embedded_io_async::Write>(
-        &self,
-        mut writer: W
-    ) -> Result<(), W::Error> {
+    async fn write_hci_async<W: embedded_io_async::Write>(&self, mut writer: W) -> Result<(), W::Error> {
         let header = SyncPacketHeader {
             handle: self.handle,
             data_len: self.data.len() as u8,
@@ -507,10 +482,7 @@ impl IsoDataLoadHeader {
     /// Create an `IsoDataLoadHeader` from `data`.
     ///
     /// `timestamp` indicates whether the data load header includes a timestamp field.
-    pub fn from_hci_bytes(
-        timestamp: bool,
-        data: &[u8]
-    ) -> Result<(Self, &[u8]), FromHciBytesError> {
+    pub fn from_hci_bytes(timestamp: bool, data: &[u8]) -> Result<(Self, &[u8]), FromHciBytesError> {
         let (timestamp, data) = if timestamp {
             u32::from_hci_bytes(data).map(|(x, y)| (Some(x), y))?
         } else {
@@ -534,7 +506,11 @@ impl IsoDataLoadHeader {
 impl WriteHci for IsoDataLoadHeader {
     #[inline(always)]
     fn size(&self) -> usize {
-        if self.timestamp.is_some() { 8 } else { 4 }
+        if self.timestamp.is_some() {
+            8
+        } else {
+            4
+        }
     }
 
     #[inline(always)]
@@ -547,10 +523,7 @@ impl WriteHci for IsoDataLoadHeader {
     }
 
     #[inline(always)]
-    async fn write_hci_async<W: embedded_io_async::Write>(
-        &self,
-        mut writer: W
-    ) -> Result<(), W::Error> {
+    async fn write_hci_async<W: embedded_io_async::Write>(&self, mut writer: W) -> Result<(), W::Error> {
         if let Some(timestamp) = self.timestamp {
             timestamp.write_hci_async(&mut writer).await?;
         }
@@ -572,7 +545,7 @@ impl<'a> IsoPacket<'a> {
     /// Create an `IsoPacket` from `header` and `data`
     pub fn from_header_hci_bytes(
         header: IsoPacketHeader,
-        data: &'a [u8]
+        data: &'a [u8],
     ) -> Result<(Self, &'a [u8]), FromHciBytesError> {
         let data_load_len = usize::from(header.data_load_len);
         if data.len() < data_load_len {
@@ -581,13 +554,10 @@ impl<'a> IsoPacket<'a> {
             let (data, rest) = data.split_at(data_load_len);
             let (data_load_header, data) = match header.boundary_flag() {
                 IsoPacketBoundary::FirstFragment | IsoPacketBoundary::Complete => {
-                    IsoDataLoadHeader::from_hci_bytes(
-                        header.has_timestamp(),
-                        &data[..data_load_len]
-                    ).map(|(x, y)| (Some(x), y))?
+                    IsoDataLoadHeader::from_hci_bytes(header.has_timestamp(), &data[..data_load_len])
+                        .map(|(x, y)| (Some(x), y))?
                 }
-                IsoPacketBoundary::ContinuationFragment | IsoPacketBoundary::LastFragment =>
-                    (None, data),
+                IsoPacketBoundary::ContinuationFragment | IsoPacketBoundary::LastFragment => (None, data),
             };
 
             Ok((
@@ -624,10 +594,7 @@ impl<'a> IsoPacket<'a> {
 
     /// Gets the size of the data section of this packet, including the [`IsoDataLoadHeader`] (if present).
     pub fn data_load_len(&self) -> usize {
-        self.data_load_header
-            .as_ref()
-            .map(|x| x.size())
-            .unwrap_or_default() + self.data.len()
+        self.data_load_header.as_ref().map(|x| x.size()).unwrap_or_default() + self.data.len()
     }
 
     /// Gets the data for this packet
@@ -646,10 +613,7 @@ impl<'de> FromHciBytes<'de> for IsoPacket<'de> {
 impl<'de> ReadHci<'de> for IsoPacket<'de> {
     const MAX_LEN: usize = 255;
 
-    fn read_hci<R: embedded_io::Read>(
-        mut reader: R,
-        buf: &'de mut [u8]
-    ) -> Result<Self, ReadHciError<R::Error>> {
+    fn read_hci<R: embedded_io::Read>(mut reader: R, buf: &'de mut [u8]) -> Result<Self, ReadHciError<R::Error>> {
         let mut header = [0; 4];
         reader.read_exact(&mut header)?;
         let (header, _) = IsoPacketHeader::from_hci_bytes(&header)?;
@@ -666,7 +630,7 @@ impl<'de> ReadHci<'de> for IsoPacket<'de> {
 
     async fn read_hci_async<R: embedded_io_async::Read>(
         mut reader: R,
-        buf: &'de mut [u8]
+        buf: &'de mut [u8],
     ) -> Result<Self, ReadHciError<R::Error>> {
         let mut header = [0; 4];
         reader.read_exact(&mut header).await?;
@@ -703,10 +667,7 @@ impl WriteHci for IsoPacket<'_> {
     }
 
     #[inline(always)]
-    async fn write_hci_async<W: embedded_io_async::Write>(
-        &self,
-        mut writer: W
-    ) -> Result<(), W::Error> {
+    async fn write_hci_async<W: embedded_io_async::Write>(&self, mut writer: W) -> Result<(), W::Error> {
         let header = IsoPacketHeader {
             handle: self.handle,
             data_load_len: self.data_load_len() as u16,

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,7 +1,15 @@
 //! HCI data packets [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-c8fdfc58-ec59-1a87-6e78-0a01de2e0846)
 
-use crate::param::{param, ConnHandle};
-use crate::{FromHciBytes, FromHciBytesError, HostToControllerPacket, PacketKind, ReadHci, ReadHciError, WriteHci};
+use crate::param::{ param, ConnHandle };
+use crate::{
+    FromHciBytes,
+    FromHciBytesError,
+    HostToControllerPacket,
+    PacketKind,
+    ReadHci,
+    ReadHciError,
+    WriteHci,
+};
 
 /// HCI ACL Data packet `Packet_Boundary_Flag` [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-49cf6aaa-b2f3-30b0-e737-5b515d3b3168)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -84,7 +92,12 @@ pub struct AclPacket<'a> {
 
 impl<'a> AclPacket<'a> {
     /// Create a new instance.
-    pub fn new(handle: ConnHandle, pbf: AclPacketBoundary, bf: AclBroadcastFlag, data: &'a [u8]) -> Self {
+    pub fn new(
+        handle: ConnHandle,
+        pbf: AclPacketBoundary,
+        bf: AclBroadcastFlag,
+        data: &'a [u8]
+    ) -> Self {
         let handle: u16 = handle.into_inner() | ((pbf as u16) << 12) | ((bf as u16) << 14);
         Self { handle, data }
     }
@@ -92,7 +105,7 @@ impl<'a> AclPacket<'a> {
     /// Create an `AclPacket` from `header` and `data`
     pub fn from_header_hci_bytes(
         header: AclPacketHeader,
-        data: &'a [u8],
+        data: &'a [u8]
     ) -> Result<(Self, &'a [u8]), FromHciBytesError> {
         let data_len = usize::from(header.data_len);
         if data.len() < data_len {
@@ -152,7 +165,10 @@ impl<'de> FromHciBytes<'de> for AclPacket<'de> {
 impl<'de> ReadHci<'de> for AclPacket<'de> {
     const MAX_LEN: usize = 255;
 
-    fn read_hci<R: embedded_io::Read>(mut reader: R, buf: &'de mut [u8]) -> Result<Self, ReadHciError<R::Error>> {
+    fn read_hci<R: embedded_io::Read>(
+        mut reader: R,
+        buf: &'de mut [u8]
+    ) -> Result<Self, ReadHciError<R::Error>> {
         let mut header = [0; 4];
         reader.read_exact(&mut header)?;
         let (header, _) = AclPacketHeader::from_hci_bytes(&header)?;
@@ -169,7 +185,7 @@ impl<'de> ReadHci<'de> for AclPacket<'de> {
 
     async fn read_hci_async<R: embedded_io_async::Read>(
         mut reader: R,
-        buf: &'de mut [u8],
+        buf: &'de mut [u8]
     ) -> Result<Self, ReadHciError<R::Error>> {
         let mut header = [0; 4];
         reader.read_exact(&mut header).await?;
@@ -186,7 +202,7 @@ impl<'de> ReadHci<'de> for AclPacket<'de> {
     }
 }
 
-impl<'a> WriteHci for AclPacket<'a> {
+impl WriteHci for AclPacket<'_> {
     #[inline(always)]
     fn size(&self) -> usize {
         4 + self.data.len()
@@ -203,7 +219,10 @@ impl<'a> WriteHci for AclPacket<'a> {
     }
 
     #[inline(always)]
-    async fn write_hci_async<W: embedded_io_async::Write>(&self, mut writer: W) -> Result<(), W::Error> {
+    async fn write_hci_async<W: embedded_io_async::Write>(
+        &self,
+        mut writer: W
+    ) -> Result<(), W::Error> {
         let header = AclPacketHeader {
             handle: self.handle,
             data_len: self.data.len() as u16,
@@ -213,7 +232,7 @@ impl<'a> WriteHci for AclPacket<'a> {
     }
 }
 
-impl<'a> HostToControllerPacket for AclPacket<'a> {
+impl HostToControllerPacket for AclPacket<'_> {
     const KIND: PacketKind = PacketKind::AclData;
 }
 
@@ -281,7 +300,7 @@ impl<'a> SyncPacket<'a> {
     /// Create a `SyncPacket` from `header` and `data`
     pub fn from_header_hci_bytes(
         header: SyncPacketHeader,
-        data: &'a [u8],
+        data: &'a [u8]
     ) -> Result<(Self, &'a [u8]), FromHciBytesError> {
         let data_len = usize::from(header.data_len);
         if data.len() < data_len {
@@ -330,7 +349,10 @@ impl<'de> FromHciBytes<'de> for SyncPacket<'de> {
 impl<'de> ReadHci<'de> for SyncPacket<'de> {
     const MAX_LEN: usize = 258;
 
-    fn read_hci<R: embedded_io::Read>(mut reader: R, buf: &'de mut [u8]) -> Result<Self, ReadHciError<R::Error>> {
+    fn read_hci<R: embedded_io::Read>(
+        mut reader: R,
+        buf: &'de mut [u8]
+    ) -> Result<Self, ReadHciError<R::Error>> {
         let mut header = [0; 3];
         reader.read_exact(&mut header)?;
         let (header, _) = SyncPacketHeader::from_hci_bytes(&header)?;
@@ -347,7 +369,7 @@ impl<'de> ReadHci<'de> for SyncPacket<'de> {
 
     async fn read_hci_async<R: embedded_io_async::Read>(
         mut reader: R,
-        buf: &'de mut [u8],
+        buf: &'de mut [u8]
     ) -> Result<Self, ReadHciError<R::Error>> {
         let mut header = [0; 3];
         reader.read_exact(&mut header).await?;
@@ -364,7 +386,7 @@ impl<'de> ReadHci<'de> for SyncPacket<'de> {
     }
 }
 
-impl<'a> WriteHci for SyncPacket<'a> {
+impl WriteHci for SyncPacket<'_> {
     #[inline(always)]
     fn size(&self) -> usize {
         4 + self.data.len()
@@ -381,7 +403,10 @@ impl<'a> WriteHci for SyncPacket<'a> {
     }
 
     #[inline(always)]
-    async fn write_hci_async<W: embedded_io_async::Write>(&self, mut writer: W) -> Result<(), W::Error> {
+    async fn write_hci_async<W: embedded_io_async::Write>(
+        &self,
+        mut writer: W
+    ) -> Result<(), W::Error> {
         let header = SyncPacketHeader {
             handle: self.handle,
             data_len: self.data.len() as u8,
@@ -391,7 +416,7 @@ impl<'a> WriteHci for SyncPacket<'a> {
     }
 }
 
-impl<'a> HostToControllerPacket for SyncPacket<'a> {
+impl HostToControllerPacket for SyncPacket<'_> {
     const KIND: PacketKind = PacketKind::SyncData;
 }
 
@@ -482,7 +507,10 @@ impl IsoDataLoadHeader {
     /// Create an `IsoDataLoadHeader` from `data`.
     ///
     /// `timestamp` indicates whether the data load header includes a timestamp field.
-    pub fn from_hci_bytes(timestamp: bool, data: &[u8]) -> Result<(Self, &[u8]), FromHciBytesError> {
+    pub fn from_hci_bytes(
+        timestamp: bool,
+        data: &[u8]
+    ) -> Result<(Self, &[u8]), FromHciBytesError> {
         let (timestamp, data) = if timestamp {
             u32::from_hci_bytes(data).map(|(x, y)| (Some(x), y))?
         } else {
@@ -506,11 +534,7 @@ impl IsoDataLoadHeader {
 impl WriteHci for IsoDataLoadHeader {
     #[inline(always)]
     fn size(&self) -> usize {
-        if self.timestamp.is_some() {
-            8
-        } else {
-            4
-        }
+        if self.timestamp.is_some() { 8 } else { 4 }
     }
 
     #[inline(always)]
@@ -523,7 +547,10 @@ impl WriteHci for IsoDataLoadHeader {
     }
 
     #[inline(always)]
-    async fn write_hci_async<W: embedded_io_async::Write>(&self, mut writer: W) -> Result<(), W::Error> {
+    async fn write_hci_async<W: embedded_io_async::Write>(
+        &self,
+        mut writer: W
+    ) -> Result<(), W::Error> {
         if let Some(timestamp) = self.timestamp {
             timestamp.write_hci_async(&mut writer).await?;
         }
@@ -545,7 +572,7 @@ impl<'a> IsoPacket<'a> {
     /// Create an `IsoPacket` from `header` and `data`
     pub fn from_header_hci_bytes(
         header: IsoPacketHeader,
-        data: &'a [u8],
+        data: &'a [u8]
     ) -> Result<(Self, &'a [u8]), FromHciBytesError> {
         let data_load_len = usize::from(header.data_load_len);
         if data.len() < data_load_len {
@@ -554,10 +581,13 @@ impl<'a> IsoPacket<'a> {
             let (data, rest) = data.split_at(data_load_len);
             let (data_load_header, data) = match header.boundary_flag() {
                 IsoPacketBoundary::FirstFragment | IsoPacketBoundary::Complete => {
-                    IsoDataLoadHeader::from_hci_bytes(header.has_timestamp(), &data[..data_load_len])
-                        .map(|(x, y)| (Some(x), y))?
+                    IsoDataLoadHeader::from_hci_bytes(
+                        header.has_timestamp(),
+                        &data[..data_load_len]
+                    ).map(|(x, y)| (Some(x), y))?
                 }
-                IsoPacketBoundary::ContinuationFragment | IsoPacketBoundary::LastFragment => (None, data),
+                IsoPacketBoundary::ContinuationFragment | IsoPacketBoundary::LastFragment =>
+                    (None, data),
             };
 
             Ok((
@@ -594,7 +624,10 @@ impl<'a> IsoPacket<'a> {
 
     /// Gets the size of the data section of this packet, including the [`IsoDataLoadHeader`] (if present).
     pub fn data_load_len(&self) -> usize {
-        self.data_load_header.as_ref().map(|x| x.size()).unwrap_or_default() + self.data.len()
+        self.data_load_header
+            .as_ref()
+            .map(|x| x.size())
+            .unwrap_or_default() + self.data.len()
     }
 
     /// Gets the data for this packet
@@ -613,7 +646,10 @@ impl<'de> FromHciBytes<'de> for IsoPacket<'de> {
 impl<'de> ReadHci<'de> for IsoPacket<'de> {
     const MAX_LEN: usize = 255;
 
-    fn read_hci<R: embedded_io::Read>(mut reader: R, buf: &'de mut [u8]) -> Result<Self, ReadHciError<R::Error>> {
+    fn read_hci<R: embedded_io::Read>(
+        mut reader: R,
+        buf: &'de mut [u8]
+    ) -> Result<Self, ReadHciError<R::Error>> {
         let mut header = [0; 4];
         reader.read_exact(&mut header)?;
         let (header, _) = IsoPacketHeader::from_hci_bytes(&header)?;
@@ -630,7 +666,7 @@ impl<'de> ReadHci<'de> for IsoPacket<'de> {
 
     async fn read_hci_async<R: embedded_io_async::Read>(
         mut reader: R,
-        buf: &'de mut [u8],
+        buf: &'de mut [u8]
     ) -> Result<Self, ReadHciError<R::Error>> {
         let mut header = [0; 4];
         reader.read_exact(&mut header).await?;
@@ -647,7 +683,7 @@ impl<'de> ReadHci<'de> for IsoPacket<'de> {
     }
 }
 
-impl<'a> WriteHci for IsoPacket<'a> {
+impl WriteHci for IsoPacket<'_> {
     #[inline(always)]
     fn size(&self) -> usize {
         4 + self.data_load_len()
@@ -667,7 +703,10 @@ impl<'a> WriteHci for IsoPacket<'a> {
     }
 
     #[inline(always)]
-    async fn write_hci_async<W: embedded_io_async::Write>(&self, mut writer: W) -> Result<(), W::Error> {
+    async fn write_hci_async<W: embedded_io_async::Write>(
+        &self,
+        mut writer: W
+    ) -> Result<(), W::Error> {
         let header = IsoPacketHeader {
             handle: self.handle,
             data_load_len: self.data_load_len() as u16,
@@ -680,7 +719,7 @@ impl<'a> WriteHci for IsoPacket<'a> {
     }
 }
 
-impl<'a> HostToControllerPacket for IsoPacket<'a> {
+impl HostToControllerPacket for IsoPacket<'_> {
     const KIND: PacketKind = PacketKind::IsoData;
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -28,9 +28,7 @@ macro_rules! events {
     (
         $(
             $(#[$attrs:meta])*
-            struct $name:ident $(< $life:lifetime >)?
-            ($code:expr)
-            {
+            struct $name:ident $(< $life:lifetime >)?($code:expr) {
                 $(
                     $(#[$field_attrs:meta])*
                     $field:ident: $ty:ty

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,10 +1,17 @@
 //! HCI events [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-d21276b6-83d0-cbc3-8295-6ff23b70a0c5)
 
-use crate::cmd::{Opcode, SyncCmd};
+use crate::cmd::{ Opcode, SyncCmd };
 use crate::param::{
-    param, ConnHandle, ConnHandleCompletedPackets, CoreSpecificationVersion, Error, LinkType, RemainingBytes, Status,
+    param,
+    ConnHandle,
+    ConnHandleCompletedPackets,
+    CoreSpecificationVersion,
+    Error,
+    LinkType,
+    RemainingBytes,
+    Status,
 };
-use crate::{FromHciBytes, FromHciBytesError, ReadHci, ReadHciError};
+use crate::{ FromHciBytes, FromHciBytesError, ReadHci, ReadHciError };
 
 pub mod le;
 
@@ -28,7 +35,9 @@ macro_rules! events {
     (
         $(
             $(#[$attrs:meta])*
-            struct $name:ident$(<$life:lifetime>)?($code:expr) {
+            struct $name:ident $(< $life:lifetime >)?
+            ($code:expr)
+            {
                 $(
                     $(#[$field_attrs:meta])*
                     $field:ident: $ty:ty
@@ -198,7 +207,10 @@ impl<'de> FromHciBytes<'de> for Event<'de> {
 impl<'de> ReadHci<'de> for Event<'de> {
     const MAX_LEN: usize = 257;
 
-    fn read_hci<R: embedded_io::Read>(mut reader: R, buf: &'de mut [u8]) -> Result<Self, ReadHciError<R::Error>> {
+    fn read_hci<R: embedded_io::Read>(
+        mut reader: R,
+        buf: &'de mut [u8]
+    ) -> Result<Self, ReadHciError<R::Error>> {
         let mut header = [0; 2];
         reader.read_exact(&mut header)?;
         let (header, _) = EventPacketHeader::from_hci_bytes(&header)?;
@@ -215,7 +227,7 @@ impl<'de> ReadHci<'de> for Event<'de> {
 
     async fn read_hci_async<R: embedded_io_async::Read>(
         mut reader: R,
-        buf: &'de mut [u8],
+        buf: &'de mut [u8]
     ) -> Result<Self, ReadHciError<R::Error>> {
         let mut header = [0; 2];
         reader.read_exact(&mut header).await?;
@@ -232,7 +244,7 @@ impl<'de> ReadHci<'de> for Event<'de> {
     }
 }
 
-impl<'a> CommandComplete<'a> {
+impl CommandComplete<'_> {
     /// Gets the connection handle associated with the command that has completed.
     ///
     /// For commands that return the connection handle provided as a parameter as
@@ -262,11 +274,7 @@ impl<'a> CommandComplete<'a> {
     pub fn return_params<C: SyncCmd>(&self) -> Result<C::Return, FromHciBytesError> {
         assert_eq!(self.cmd_opcode, C::OPCODE);
         C::Return::from_hci_bytes(&self.return_param_bytes).and_then(|(params, rest)| {
-            if rest.is_empty() {
-                Ok(params)
-            } else {
-                Err(FromHciBytesError::InvalidSize)
-            }
+            if rest.is_empty() { Ok(params) } else { Err(FromHciBytesError::InvalidSize) }
         })
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -28,7 +28,7 @@ macro_rules! events {
     (
         $(
             $(#[$attrs:meta])*
-            struct $name:ident $(< $life:lifetime >)?($code:expr) {
+            struct $name:ident$(<$life:lifetime>)?($code:expr) {
                 $(
                     $(#[$field_attrs:meta])*
                     $field:ident: $ty:ty

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,17 +1,10 @@
 //! HCI events [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-d21276b6-83d0-cbc3-8295-6ff23b70a0c5)
 
-use crate::cmd::{ Opcode, SyncCmd };
+use crate::cmd::{Opcode, SyncCmd};
 use crate::param::{
-    param,
-    ConnHandle,
-    ConnHandleCompletedPackets,
-    CoreSpecificationVersion,
-    Error,
-    LinkType,
-    RemainingBytes,
-    Status,
+    param, ConnHandle, ConnHandleCompletedPackets, CoreSpecificationVersion, Error, LinkType, RemainingBytes, Status,
 };
-use crate::{ FromHciBytes, FromHciBytesError, ReadHci, ReadHciError };
+use crate::{FromHciBytes, FromHciBytesError, ReadHci, ReadHciError};
 
 pub mod le;
 
@@ -207,10 +200,7 @@ impl<'de> FromHciBytes<'de> for Event<'de> {
 impl<'de> ReadHci<'de> for Event<'de> {
     const MAX_LEN: usize = 257;
 
-    fn read_hci<R: embedded_io::Read>(
-        mut reader: R,
-        buf: &'de mut [u8]
-    ) -> Result<Self, ReadHciError<R::Error>> {
+    fn read_hci<R: embedded_io::Read>(mut reader: R, buf: &'de mut [u8]) -> Result<Self, ReadHciError<R::Error>> {
         let mut header = [0; 2];
         reader.read_exact(&mut header)?;
         let (header, _) = EventPacketHeader::from_hci_bytes(&header)?;
@@ -227,7 +217,7 @@ impl<'de> ReadHci<'de> for Event<'de> {
 
     async fn read_hci_async<R: embedded_io_async::Read>(
         mut reader: R,
-        buf: &'de mut [u8]
+        buf: &'de mut [u8],
     ) -> Result<Self, ReadHciError<R::Error>> {
         let mut header = [0; 2];
         reader.read_exact(&mut header).await?;
@@ -274,7 +264,11 @@ impl CommandComplete<'_> {
     pub fn return_params<C: SyncCmd>(&self) -> Result<C::Return, FromHciBytesError> {
         assert_eq!(self.cmd_opcode, C::OPCODE);
         C::Return::from_hci_bytes(&self.return_param_bytes).and_then(|(params, rest)| {
-            if rest.is_empty() { Ok(params) } else { Err(FromHciBytesError::InvalidSize) }
+            if rest.is_empty() {
+                Ok(params)
+            } else {
+                Err(FromHciBytesError::InvalidSize)
+            }
         })
     }
 }

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,7 +1,7 @@
 #![macro_use]
 #![allow(unused_macros)]
 
-use core::fmt::{Debug, Display, LowerHex};
+use core::fmt::{ Debug, Display, LowerHex };
 
 #[cfg(all(feature = "defmt", feature = "log"))]
 compile_error!("You may not enable both `defmt` and `log` features.");
@@ -190,14 +190,14 @@ macro_rules! unwrap {
             }
         }
     };
-    ($arg:expr, $($msg:expr),+ $(,)? ) => {
+    ($arg:expr, $($msg:expr),+ $(,)?) => {
         match $crate::fmt::Try::into_result($arg) {
             ::core::result::Result::Ok(t) => t,
             ::core::result::Result::Err(e) => {
                 ::core::panic!("unwrap of `{}` failed: {}: {:?}", ::core::stringify!($arg), ::core::format_args!($($msg,)*), e);
             }
         }
-    }
+    };
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -232,19 +232,19 @@ impl<T, E> Try for Result<T, E> {
 #[allow(unused)]
 pub(crate) struct Bytes<'a>(pub &'a [u8]);
 
-impl<'a> Debug for Bytes<'a> {
+impl Debug for Bytes<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:#02x?}", self.0)
     }
 }
 
-impl<'a> Display for Bytes<'a> {
+impl Display for Bytes<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:#02x?}", self.0)
     }
 }
 
-impl<'a> LowerHex for Bytes<'a> {
+impl LowerHex for Bytes<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:#02x?}", self.0)
     }

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -190,14 +190,14 @@ macro_rules! unwrap {
             }
         }
     };
-    ($arg:expr, $($msg:expr),+ $(,)?) => {
+    ($arg:expr, $($msg:expr),+ $(,)? ) => {
         match $crate::fmt::Try::into_result($arg) {
             ::core::result::Result::Ok(t) => t,
             ::core::result::Result::Err(e) => {
                 ::core::panic!("unwrap of `{}` failed: {}: {:?}", ::core::stringify!($arg), ::core::format_args!($($msg,)*), e);
             }
         }
-    };
+    }
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,7 +1,7 @@
 #![macro_use]
 #![allow(unused_macros)]
 
-use core::fmt::{ Debug, Display, LowerHex };
+use core::fmt::{Debug, Display, LowerHex};
 
 #[cfg(all(feature = "defmt", feature = "log"))]
 compile_error!("You may not enable both `defmt` and `log` features.");

--- a/src/param.rs
+++ b/src/param.rs
@@ -195,7 +195,7 @@ impl<const US: u16> ExtDuration<US> {
     /// Create a new instance from raw value.
     #[inline(always)]
     pub fn from_u32(val: u32) -> Self {
-        assert!(val < 1 << 24);
+        assert!(val < (1 << 24));
         Self(*unwrap!(val.to_le_bytes().first_chunk()))
     }
 
@@ -291,10 +291,10 @@ impl CoreSpecificationVersion {
     pub const VERSION_4_1: CoreSpecificationVersion = CoreSpecificationVersion(0x07);
     pub const VERSION_4_2: CoreSpecificationVersion = CoreSpecificationVersion(0x08);
     pub const VERSION_5_0: CoreSpecificationVersion = CoreSpecificationVersion(0x09);
-    pub const VERSION_5_1: CoreSpecificationVersion = CoreSpecificationVersion(0x0a);
-    pub const VERSION_5_2: CoreSpecificationVersion = CoreSpecificationVersion(0x0b);
-    pub const VERSION_5_3: CoreSpecificationVersion = CoreSpecificationVersion(0x0c);
-    pub const VERSION_5_4: CoreSpecificationVersion = CoreSpecificationVersion(0x0d);
+    pub const VERSION_5_1: CoreSpecificationVersion = CoreSpecificationVersion(0x0A);
+    pub const VERSION_5_2: CoreSpecificationVersion = CoreSpecificationVersion(0x0B);
+    pub const VERSION_5_3: CoreSpecificationVersion = CoreSpecificationVersion(0x0C);
+    pub const VERSION_5_4: CoreSpecificationVersion = CoreSpecificationVersion(0x0D);
 }
 
 unsafe impl ByteAlignedValue for CoreSpecificationVersion {}

--- a/src/param.rs
+++ b/src/param.rs
@@ -1,13 +1,6 @@
 //! Parameter types for HCI command and event packets [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-8af7a4d8-7a08-0895-b041-fdf9e27d6508)
 
-use crate::{
-    AsHciBytes,
-    ByteAlignedValue,
-    FixedSizeValue,
-    FromHciBytes,
-    FromHciBytesError,
-    WriteHci,
-};
+use crate::{AsHciBytes, ByteAlignedValue, FixedSizeValue, FromHciBytes, FromHciBytesError, WriteHci};
 
 mod cmd_mask;
 mod event_masks;
@@ -21,7 +14,7 @@ pub use cmd_mask::*;
 pub use event_masks::*;
 pub use feature_masks::*;
 pub use le::*;
-pub(crate) use macros::{ param, param_slice };
+pub(crate) use macros::{param, param_slice};
 pub use status::*;
 
 /// A special parameter which takes all remaining bytes in the buffer
@@ -50,10 +43,7 @@ impl WriteHci for RemainingBytes<'_> {
     }
 
     #[inline(always)]
-    async fn write_hci_async<W: embedded_io_async::Write>(
-        &self,
-        mut writer: W
-    ) -> Result<(), W::Error> {
+    async fn write_hci_async<W: embedded_io_async::Write>(&self, mut writer: W) -> Result<(), W::Error> {
         writer.write_all(self.0).await
     }
 }

--- a/src/param.rs
+++ b/src/param.rs
@@ -1,6 +1,13 @@
 //! Parameter types for HCI command and event packets [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-8af7a4d8-7a08-0895-b041-fdf9e27d6508)
 
-use crate::{AsHciBytes, ByteAlignedValue, FixedSizeValue, FromHciBytes, FromHciBytesError, WriteHci};
+use crate::{
+    AsHciBytes,
+    ByteAlignedValue,
+    FixedSizeValue,
+    FromHciBytes,
+    FromHciBytesError,
+    WriteHci,
+};
 
 mod cmd_mask;
 mod event_masks;
@@ -14,7 +21,7 @@ pub use cmd_mask::*;
 pub use event_masks::*;
 pub use feature_masks::*;
 pub use le::*;
-pub(crate) use macros::{param, param_slice};
+pub(crate) use macros::{ param, param_slice };
 pub use status::*;
 
 /// A special parameter which takes all remaining bytes in the buffer
@@ -23,7 +30,7 @@ pub use status::*;
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RemainingBytes<'a>(&'a [u8]);
 
-impl<'a> core::ops::Deref for RemainingBytes<'a> {
+impl core::ops::Deref for RemainingBytes<'_> {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
@@ -31,7 +38,7 @@ impl<'a> core::ops::Deref for RemainingBytes<'a> {
     }
 }
 
-impl<'a> WriteHci for RemainingBytes<'a> {
+impl WriteHci for RemainingBytes<'_> {
     #[inline(always)]
     fn size(&self) -> usize {
         self.0.len()
@@ -43,7 +50,10 @@ impl<'a> WriteHci for RemainingBytes<'a> {
     }
 
     #[inline(always)]
-    async fn write_hci_async<W: embedded_io_async::Write>(&self, mut writer: W) -> Result<(), W::Error> {
+    async fn write_hci_async<W: embedded_io_async::Write>(
+        &self,
+        mut writer: W
+    ) -> Result<(), W::Error> {
         writer.write_all(self.0).await
     }
 }
@@ -195,7 +205,7 @@ impl<const US: u16> ExtDuration<US> {
     /// Create a new instance from raw value.
     #[inline(always)]
     pub fn from_u32(val: u32) -> Self {
-        assert!(val < (1 << 24));
+        assert!(val < 1 << 24);
         Self(*unwrap!(val.to_le_bytes().first_chunk()))
     }
 
@@ -291,10 +301,10 @@ impl CoreSpecificationVersion {
     pub const VERSION_4_1: CoreSpecificationVersion = CoreSpecificationVersion(0x07);
     pub const VERSION_4_2: CoreSpecificationVersion = CoreSpecificationVersion(0x08);
     pub const VERSION_5_0: CoreSpecificationVersion = CoreSpecificationVersion(0x09);
-    pub const VERSION_5_1: CoreSpecificationVersion = CoreSpecificationVersion(0x0A);
-    pub const VERSION_5_2: CoreSpecificationVersion = CoreSpecificationVersion(0x0B);
-    pub const VERSION_5_3: CoreSpecificationVersion = CoreSpecificationVersion(0x0C);
-    pub const VERSION_5_4: CoreSpecificationVersion = CoreSpecificationVersion(0x0D);
+    pub const VERSION_5_1: CoreSpecificationVersion = CoreSpecificationVersion(0x0a);
+    pub const VERSION_5_2: CoreSpecificationVersion = CoreSpecificationVersion(0x0b);
+    pub const VERSION_5_3: CoreSpecificationVersion = CoreSpecificationVersion(0x0c);
+    pub const VERSION_5_4: CoreSpecificationVersion = CoreSpecificationVersion(0x0d);
 }
 
 unsafe impl ByteAlignedValue for CoreSpecificationVersion {}

--- a/src/param.rs
+++ b/src/param.rs
@@ -58,7 +58,7 @@ impl WriteHci for RemainingBytes<'_> {
     }
 }
 
-impl<'a> AsHciBytes for RemainingBytes<'a> {
+impl AsHciBytes for RemainingBytes<'_> {
     fn as_hci_bytes(&self) -> &[u8] {
         self.0
     }

--- a/src/param/le.rs
+++ b/src/param/le.rs
@@ -556,7 +556,7 @@ param! {
     }
 }
 
-impl<'a> LeAdvReports<'a> {
+impl LeAdvReports<'_> {
     /// Check if there are more reports available.
     pub fn is_empty(&self) -> bool {
         self.num_reports == 0
@@ -608,13 +608,13 @@ impl<'a> Iterator for LeAdvReportsIter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for LeAdvReportsIter<'a> {
+impl ExactSizeIterator for LeAdvReportsIter<'_> {
     fn len(&self) -> usize {
         self.len
     }
 }
 
-impl<'a> FusedIterator for LeAdvReportsIter<'a> {}
+impl FusedIterator for LeAdvReportsIter<'_> {}
 
 param! {
     struct LeExtAdvReport<'a> {
@@ -633,7 +633,7 @@ param! {
     }
 }
 
-impl<'a> LeExtAdvReports<'a> {
+impl LeExtAdvReports<'_> {
     /// Check if there are more reports available.
     pub fn is_empty(&self) -> bool {
         self.num_reports == 0
@@ -685,13 +685,13 @@ impl<'a> Iterator for LeExtAdvReportsIter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for LeExtAdvReportsIter<'a> {
+impl ExactSizeIterator for LeExtAdvReportsIter<'_> {
     fn len(&self) -> usize {
         self.len
     }
 }
 
-impl<'a> FusedIterator for LeExtAdvReportsIter<'a> {}
+impl FusedIterator for LeExtAdvReportsIter<'_> {}
 
 param! {
     struct LePeriodicAdvSubeventData<'a> {

--- a/src/param/primitives.rs
+++ b/src/param/primitives.rs
@@ -1,4 +1,4 @@
-use crate::{ByteAlignedValue, FixedSizeValue, FromHciBytes, FromHciBytesError, WriteHci};
+use crate::{ ByteAlignedValue, FixedSizeValue, FromHciBytes, FromHciBytesError, WriteHci };
 
 unsafe impl FixedSizeValue for () {
     #[inline(always)]
@@ -32,7 +32,7 @@ impl<'de> FromHciBytes<'de> for &'de bool {
     }
 }
 
-impl<'a> WriteHci for &'a [u8] {
+impl WriteHci for &[u8] {
     #[inline(always)]
     fn size(&self) -> usize {
         self.len()
@@ -45,7 +45,10 @@ impl<'a> WriteHci for &'a [u8] {
     }
 
     #[inline(always)]
-    async fn write_hci_async<W: embedded_io_async::Write>(&self, mut writer: W) -> Result<(), W::Error> {
+    async fn write_hci_async<W: embedded_io_async::Write>(
+        &self,
+        mut writer: W
+    ) -> Result<(), W::Error> {
         writer.write_all(&[self.size() as u8]).await?;
         writer.write_all(self).await
     }
@@ -70,7 +73,9 @@ impl<'de, T: ByteAlignedValue, const N: usize> FromHciBytes<'de> for &'de [T; N]
 impl<T: WriteHci> WriteHci for Option<T> {
     #[inline(always)]
     fn size(&self) -> usize {
-        self.as_ref().map(|x| x.size()).unwrap_or_default()
+        self.as_ref()
+            .map(|x| x.size())
+            .unwrap_or_default()
     }
 
     #[inline(always)]
@@ -82,7 +87,10 @@ impl<T: WriteHci> WriteHci for Option<T> {
     }
 
     #[inline(always)]
-    async fn write_hci_async<W: embedded_io_async::Write>(&self, writer: W) -> Result<(), W::Error> {
+    async fn write_hci_async<W: embedded_io_async::Write>(
+        &self,
+        writer: W
+    ) -> Result<(), W::Error> {
         match self {
             Some(val) => val.write_hci_async(writer).await,
             None => Ok(()),

--- a/src/param/primitives.rs
+++ b/src/param/primitives.rs
@@ -1,4 +1,4 @@
-use crate::{ ByteAlignedValue, FixedSizeValue, FromHciBytes, FromHciBytesError, WriteHci };
+use crate::{ByteAlignedValue, FixedSizeValue, FromHciBytes, FromHciBytesError, WriteHci};
 
 unsafe impl FixedSizeValue for () {
     #[inline(always)]
@@ -45,10 +45,7 @@ impl WriteHci for &[u8] {
     }
 
     #[inline(always)]
-    async fn write_hci_async<W: embedded_io_async::Write>(
-        &self,
-        mut writer: W
-    ) -> Result<(), W::Error> {
+    async fn write_hci_async<W: embedded_io_async::Write>(&self, mut writer: W) -> Result<(), W::Error> {
         writer.write_all(&[self.size() as u8]).await?;
         writer.write_all(self).await
     }
@@ -73,9 +70,7 @@ impl<'de, T: ByteAlignedValue, const N: usize> FromHciBytes<'de> for &'de [T; N]
 impl<T: WriteHci> WriteHci for Option<T> {
     #[inline(always)]
     fn size(&self) -> usize {
-        self.as_ref()
-            .map(|x| x.size())
-            .unwrap_or_default()
+        self.as_ref().map(|x| x.size()).unwrap_or_default()
     }
 
     #[inline(always)]
@@ -87,10 +82,7 @@ impl<T: WriteHci> WriteHci for Option<T> {
     }
 
     #[inline(always)]
-    async fn write_hci_async<W: embedded_io_async::Write>(
-        &self,
-        writer: W
-    ) -> Result<(), W::Error> {
+    async fn write_hci_async<W: embedded_io_async::Write>(&self, writer: W) -> Result<(), W::Error> {
         match self {
             Some(val) => val.write_hci_async(writer).await,
             None => Ok(()),

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -4,17 +4,30 @@ use core::future::Future;
 
 use embassy_sync::blocking_mutex::raw::RawMutex;
 use embassy_sync::mutex::Mutex;
-use embedded_io::{ErrorType, ReadExactError};
+use embedded_io::{ ErrorType, ReadExactError };
 
 use crate::controller::blocking::TryError;
-use crate::{ControllerToHostPacket, FromHciBytesError, HostToControllerPacket, ReadHci, ReadHciError, WriteHci};
+use crate::{
+    ControllerToHostPacket,
+    FromHciBytesError,
+    HostToControllerPacket,
+    ReadHci,
+    ReadHciError,
+    WriteHci,
+};
 
 /// A packet-oriented HCI Transport Layer
 pub trait Transport: embedded_io::ErrorType {
     /// Read a complete HCI packet into the rx buffer
-    fn read<'a>(&self, rx: &'a mut [u8]) -> impl Future<Output = Result<ControllerToHostPacket<'a>, Self::Error>>;
+    fn read<'a>(
+        &self,
+        rx: &'a mut [u8]
+    ) -> impl Future<Output = Result<ControllerToHostPacket<'a>, Self::Error>>;
     /// Write a complete HCI packet from the tx buffer
-    fn write<T: HostToControllerPacket>(&self, val: &T) -> impl Future<Output = Result<(), Self::Error>>;
+    fn write<T: HostToControllerPacket>(
+        &self,
+        val: &T
+    ) -> impl Future<Output = Result<(), Self::Error>>;
 }
 
 /// HCI transport layer for a split serial bus using the UART transport layer protocol [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/uart-transport-layer.html)
@@ -66,7 +79,11 @@ impl<E: embedded_io::Error> From<FromHciBytesError> for Error<E> {
     }
 }
 
-impl<M: RawMutex, R: embedded_io_async::Read, W: embedded_io_async::Write> SerialTransport<M, R, W> {
+impl<M: RawMutex, R: embedded_io_async::Read, W: embedded_io_async::Write> SerialTransport<
+    M,
+    R,
+    W
+> {
     /// Create a new instance.
     pub fn new(reader: R, writer: W) -> Self {
         Self {
@@ -77,46 +94,45 @@ impl<M: RawMutex, R: embedded_io_async::Read, W: embedded_io_async::Write> Seria
 }
 
 impl<
-        M: RawMutex,
-        R: embedded_io::ErrorType<Error = E>,
-        W: embedded_io::ErrorType<Error = E>,
-        E: embedded_io::Error,
-    > ErrorType for SerialTransport<M, R, W>
-{
+    M: RawMutex,
+    R: embedded_io::ErrorType<Error = E>,
+    W: embedded_io::ErrorType<Error = E>,
+    E: embedded_io::Error
+> ErrorType for SerialTransport<M, R, W> {
     type Error = Error<E>;
 }
 
 impl<
-        M: RawMutex,
-        R: embedded_io_async::Read<Error = E>,
-        W: embedded_io_async::Write<Error = E>,
-        E: embedded_io::Error,
-    > Transport for SerialTransport<M, R, W>
-{
+    M: RawMutex,
+    R: embedded_io_async::Read<Error = E>,
+    W: embedded_io_async::Write<Error = E>,
+    E: embedded_io::Error
+> Transport for SerialTransport<M, R, W> {
     async fn read<'a>(&self, rx: &'a mut [u8]) -> Result<ControllerToHostPacket<'a>, Self::Error> {
         let mut r = self.reader.lock().await;
-        ControllerToHostPacket::read_hci_async(&mut *r, rx)
-            .await
-            .map_err(Error::Read)
+        ControllerToHostPacket::read_hci_async(&mut *r, rx).await.map_err(Error::Read)
     }
 
     async fn write<T: HostToControllerPacket>(&self, tx: &T) -> Result<(), Self::Error> {
         let mut w = self.writer.lock().await;
         WithIndicator(tx)
-            .write_hci_async(&mut *w)
-            .await
+            .write_hci_async(&mut *w).await
             .map_err(|e| Error::Write(e))
     }
 }
 
-impl<M: RawMutex, R: embedded_io::Read<Error = E>, W: embedded_io::Write<Error = E>, E: embedded_io::Error>
-    blocking::Transport for SerialTransport<M, R, W>
-{
-    fn read<'a>(&self, rx: &'a mut [u8]) -> Result<ControllerToHostPacket<'a>, TryError<Self::Error>> {
+impl<
+    M: RawMutex,
+    R: embedded_io::Read<Error = E>,
+    W: embedded_io::Write<Error = E>,
+    E: embedded_io::Error
+> blocking::Transport for SerialTransport<M, R, W> {
+    fn read<'a>(
+        &self,
+        rx: &'a mut [u8]
+    ) -> Result<ControllerToHostPacket<'a>, TryError<Self::Error>> {
         let mut r = self.reader.try_lock().map_err(|_| TryError::Busy)?;
-        ControllerToHostPacket::read_hci(&mut *r, rx)
-            .map_err(Error::Read)
-            .map_err(TryError::Error)
+        ControllerToHostPacket::read_hci(&mut *r, rx).map_err(Error::Read).map_err(TryError::Error)
     }
 
     fn write<T: HostToControllerPacket>(&self, tx: &T) -> Result<(), TryError<Self::Error>> {
@@ -141,7 +157,7 @@ impl<'a, T: HostToControllerPacket> WithIndicator<'a, T> {
     }
 }
 
-impl<'a, T: HostToControllerPacket> WriteHci for WithIndicator<'a, T> {
+impl<T: HostToControllerPacket> WriteHci for WithIndicator<'_, T> {
     #[inline(always)]
     fn size(&self) -> usize {
         1 + self.0.size()
@@ -154,7 +170,10 @@ impl<'a, T: HostToControllerPacket> WriteHci for WithIndicator<'a, T> {
     }
 
     #[inline(always)]
-    async fn write_hci_async<W: embedded_io_async::Write>(&self, mut writer: W) -> Result<(), W::Error> {
+    async fn write_hci_async<W: embedded_io_async::Write>(
+        &self,
+        mut writer: W
+    ) -> Result<(), W::Error> {
         T::KIND.write_hci_async(&mut writer).await?;
         self.0.write_hci_async(writer).await
     }
@@ -168,7 +187,10 @@ pub mod blocking {
     /// A packet-oriented HCI Transport Layer
     pub trait Transport: embedded_io::ErrorType {
         /// Read a complete HCI packet into the rx buffer
-        fn read<'a>(&self, rx: &'a mut [u8]) -> Result<ControllerToHostPacket<'a>, TryError<Self::Error>>;
+        fn read<'a>(
+            &self,
+            rx: &'a mut [u8]
+        ) -> Result<ControllerToHostPacket<'a>, TryError<Self::Error>>;
         /// Write a complete HCI packet from the tx buffer
         fn write<T: HostToControllerPacket>(&self, val: &T) -> Result<(), TryError<Self::Error>>;
     }


### PR DESCRIPTION
This PR is focused on getting rid of clippy nightly warnings based on redundant lifetimes. It aims to solve the issue listed in https://github.com/embassy-rs/bt-hci/issues/21.

I did find that I had to turn my format on save off when doing this PR as it would break my imports in some of the files resulting in a mess of errors.

The code still builds in both nightly and stable and clippy no longer has any warnings in either stable or nightly :)
