### PR TITLE
chore!: fix typos

### DIFF
--- a/src/param.rs
+++ b/src/param.rs
@@ -98,7 +98,7 @@ impl ConnHandle {
     }
 }
 
-/// A 16-bit duration. The `US` generic paramter indicates the timebase in µs.
+/// A 16-bit duration. The `US` generic parameter indicates the timebase in µs.
 #[repr(transparent)]
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/src/param/le.rs
+++ b/src/param/le.rs
@@ -380,7 +380,7 @@ param! {
 param! {
     bitfield LeDataRelatedAddrChangeReasons[1] {
         (0, change_on_adv_data_change, set_change_addr_on_adv_data_changes);
-        (1, change_on_scan_repsonse_data_change, set_change_addr_on_scan_response_data_changes);
+        (1, change_on_scan_response_data_change, set_change_addr_on_scan_response_data_changes);
     }
 }
 

--- a/update_uuids/src/writer.rs
+++ b/update_uuids/src/writer.rs
@@ -48,7 +48,7 @@ pub const {}: BluetoothUuid16 = BluetoothUuid16::new(0x{:x});",
 
 /// Update the Appearance values in the source code
 ///
-/// Subcatagories are dealt with as submodules.
+/// Subcategories are dealt with as submodules.
 pub fn update_appearance(output_folder: &Path, input: &[Category], commit_hash: &str) -> Result<(), Box<dyn Error>> {
     let output_folder = output_folder.join("appearance");
     let (module_name, mut file) = setup_rust_file("categories", output_folder)?;


### PR DESCRIPTION
Fixing `change_on_scan_repsonse_data_change` is a breaking change.