### PR TITLE
Do not require one byte length slice when validating bool

### DIFF
--- a/src/param/primitives.rs
+++ b/src/param/primitives.rs
@@ -19,7 +19,7 @@ impl<'de> FromHciBytes<'de> for &'static () {
 unsafe impl FixedSizeValue for bool {
     #[inline(always)]
     fn is_valid(data: &[u8]) -> bool {
-        data.len() == 1 && data[0] < 2
+        data.len() >= 1 && data[0] < 2
     }
 }
 

--- a/src/param/primitives.rs
+++ b/src/param/primitives.rs
@@ -19,7 +19,7 @@ impl<'de> FromHciBytes<'de> for &'static () {
 unsafe impl FixedSizeValue for bool {
     #[inline(always)]
     fn is_valid(data: &[u8]) -> bool {
-        data.len() >= 1 && data[0] < 2
+        !data.is_empty() && data[0] < 2
     }
 }
 


### PR DESCRIPTION
Using trouble with the nrf-sdc crate I was not able to read the `EncryptionChangeV1` event. `Controller::read` returned `Error::EINVAL` which seems to be originating from the validation of the `EncryptionChangeV1` `enabled` parameter.
My fix is to allow the provided slice to be longer than one to the bool `is_valid` function.