### PR TITLE
Added support for serialization of param using serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,8 +39,10 @@ dependencies = [
  "embedded-io",
  "embedded-io-async",
  "futures-intrusive",
- "heapless",
+ "heapless 0.8.0",
  "log",
+ "postcard",
+ "serde",
  "uuid",
 ]
 
@@ -57,6 +68,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
 name = "critical-section"
@@ -115,7 +132,7 @@ dependencies = [
  "critical-section",
  "embedded-io-async",
  "futures-util",
- "heapless",
+ "heapless 0.8.0",
 ]
 
 [[package]]
@@ -253,6 +270,15 @@ dependencies = [
 
 [[package]]
 name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
@@ -268,11 +294,25 @@ checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32 0.2.1",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "hash32",
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -437,6 +477,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
+name = "postcard"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
+dependencies = [
+ "cobs",
+ "heapless 0.7.17",
+ "serde",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +530,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +558,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
@@ -537,6 +603,15 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,18 @@ documentation = "https://docs.rs/bt-hci"
 keywords = ["bluetooth", "hci", "BLE"]
 categories = ["embedded", "hardware-support", "no-std"]
 rust-version = "1.77"
-exclude = [".github", ".vscode", "ci.sh", "rust-toolchain.toml", "rustfmt.toml", "update_uuids"]
+exclude = [
+    ".github",
+    ".vscode",
+    "ci.sh",
+    "rust-toolchain.toml",
+    "rustfmt.toml",
+    "update_uuids",
+]
 
 [features]
 defmt = ["dep:defmt", "embedded-io/defmt-03", "embedded-io-async/defmt-03"]
+serde = ["dep:serde"]
 
 [dependencies]
 defmt = { version = "0.3", optional = true }
@@ -25,6 +33,12 @@ embassy-time = { version = ">=0.3, <0.5", optional = true }
 heapless = "0.8"
 futures-intrusive = { version = "0.5.0", default-features = false }
 uuid = { version = "1.11.0", default-features = false, optional = true }
+serde = { version = "1.0", optional = true, features = [
+    "derive",
+], default-features = false }
+
+[dev-dependencies]
+postcard = "1.1"
 
 [workspace]
 members = ["update_uuids"]

--- a/ci.sh
+++ b/ci.sh
@@ -15,4 +15,6 @@ cargo clippy --features defmt,embassy-time
 cargo clippy --features log
 cargo clippy --features log,embassy-time
 
-cargo test --features embassy-time
+cargo clippy --features serde
+
+cargo test --features embassy-time,serde

--- a/src/param.rs
+++ b/src/param.rs
@@ -335,6 +335,9 @@ impl ConnHandleCompletedPackets {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "serde")]
+    use postcard;
+
     use super::*;
 
     #[test]
@@ -343,5 +346,30 @@ mod tests {
 
         assert_eq!(completed.handle().unwrap(), ConnHandle::new(42));
         assert_eq!(completed.num_completed_packets().unwrap(), 2334);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serialize_bdaddr() {
+        let bytes = [0x01, 0xaa, 0x55, 0x04, 0x05, 0xfe];
+
+        let address = BdAddr::new(bytes);
+
+        let mut buffer = [0u8; 32];
+        let vykort = postcard::to_slice(&address, &mut buffer).unwrap();
+
+        assert_eq!(vykort, &bytes);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_deserialize_bdaddr() {
+        let bytes = [0xff, 0x5a, 0xa5, 0x00, 0x05, 0xfe];
+
+        let address = postcard::from_bytes::<BdAddr>(&bytes).unwrap();
+
+        let expected = BdAddr::new(bytes);
+
+        assert_eq!(address, expected);
     }
 }

--- a/src/param/macros.rs
+++ b/src/param/macros.rs
@@ -44,6 +44,7 @@ macro_rules! param {
         #[repr(transparent)]
         #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
         /// $name
         pub struct $name($wrapped);
 


### PR DESCRIPTION
This PR adds support for serialisation and de-serialisation of structs generated with the param macro, like BdAddr. This because it might be useful for loading and storing the address.

The current implementation just use the serde macros, which results in a byte array. For textual representations this might not look like a Bluetooth device address (`a1:b2:c3:d4:e5:f6`) that would be formatted as,

```rust
write!(
    w,
    "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
    address[5], address[4], address[3], address[2], address[1], address[0]
)
```
