### PR TITLE
Add 1 to the size of WriteHci-serialized byte slices

### DIFF
--- a/src/param/primitives.rs
+++ b/src/param/primitives.rs
@@ -35,6 +35,7 @@ impl<'de> FromHciBytes<'de> for &'de bool {
 impl WriteHci for &[u8] {
     #[inline(always)]
     fn size(&self) -> usize {
+        // Slice length is incremented to account for the prepended length byte
         self.len() + 1
     }
 

--- a/src/param/primitives.rs
+++ b/src/param/primitives.rs
@@ -40,7 +40,7 @@ impl WriteHci for &[u8] {
 
     #[inline(always)]
     fn write_hci<W: embedded_io::Write>(&self, mut writer: W) -> Result<(), W::Error> {
-        writer.write_all(&[self.size() as u8])?;
+        writer.write_all(&[self.len() as u8])?;
         writer.write_all(self)
     }
 

--- a/src/param/primitives.rs
+++ b/src/param/primitives.rs
@@ -35,7 +35,7 @@ impl<'de> FromHciBytes<'de> for &'de bool {
 impl WriteHci for &[u8] {
     #[inline(always)]
     fn size(&self) -> usize {
-        self.len()
+        self.len() + 1
     }
 
     #[inline(always)]


### PR DESCRIPTION
This PR makes the implementation of `WriteHci::size(slice)` match the behavior of every other location where this method is defined.

`WriteHci` prepends the slice size to the `Writer` before writing all data.

Since `WriteHci::size()` did not account for this, `Transport` implementations that rely on this value end up discarding a byte per param slice from messages, see:  https://github.com/esp-rs/esp-hal/blob/main/esp-wifi/src/ble/controller/mod.rs#L207

Let me know if this is intended behavior - but I believe this could easily have been missed because it doesn't apply to the nRF or SerialTransport HCI interface mechanisms.