### PR TITLE
Add missing fields to `LeExtAdvReport`

### DIFF
--- a/src/param/le.rs
+++ b/src/param/le.rs
@@ -621,8 +621,15 @@ param! {
         event_kind: LeExtAdvEventKind,
         addr_kind: AddrKind,
         addr: BdAddr,
-        data: &'a [u8],
+        primary_adv_phy: PhyKind,
+        secondary_adv_phy: PhyKind,
+        adv_sid: u8,
+        tx_power: i8,
         rssi: i8,
+        adv_interval: Duration<1_250>,
+        direct_addr_kind: AddrKind,
+        direct_addr: BdAddr,
+        data: &'a [u8],
     }
 }
 


### PR DESCRIPTION
This PR adds the missing fields to `LeExtAdvReport` from the [spec](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-37c674d6-c93f-c46c-420a-b2569dff4fa0).

Presently, the Primary PHY is being misinterpreted as the `data` length value.