### PR TITLE
Add `LeSetExtAdvParamsV2` from BLE5.4

### DIFF
--- a/src/cmd/le.rs
+++ b/src/cmd/le.rs
@@ -1,8 +1,8 @@
 //! LE Controller commands [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-0f07d2b9-81e3-6508-ee08-8c808e468fed)
 
 use crate::param::{
-    AddrKind, AdvChannelMap, AdvEventProps, AdvFilterPolicy, AdvHandle, AdvKind, AdvSet, AllPhys, BdAddr, ChannelMap,
-    ConnHandle, CteKind, CteMask, Duration, ExtDuration, FilterDuplicates, InitiatingPhy,
+    AddrKind, AdvChannelMap, AdvEventProps, AdvFilterPolicy, AdvHandle, AdvKind, AdvPhyOptions, AdvSet, AllPhys,
+    BdAddr, ChannelMap, ConnHandle, CteKind, CteMask, Duration, ExtDuration, FilterDuplicates, InitiatingPhy,
     LeDataRelatedAddrChangeReasons, LeEventMask, LeFeatureMask, LePeriodicAdvCreateSyncOptions,
     LePeriodicAdvReceiveEnable, LePeriodicAdvSubeventData, LePeriodicAdvSyncTransferMode, LeScanKind, Operation,
     PeriodicAdvProps, PhyKind, PhyMask, PhyOptions, PhyParams, PrivacyMode, ScanningFilterPolicy, ScanningPhy,
@@ -469,6 +469,32 @@ cmd! {
                 secondary_adv_phy: PhyKind,
                 adv_sid: u8,
                 scan_request_notification_enable: bool,
+        }
+        Return = i8;
+    }
+}
+
+cmd! {
+    /// LE Set Extended Advertising Parameters command [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-2d5f3e1f-6666-baa9-dcc2-5d8af3709dac)
+    LeSetExtAdvParamsV2(LE, 0x007F) {
+        LeSetExtAdvParamsV2Params {
+                adv_handle: AdvHandle,
+                adv_event_props: AdvEventProps,
+                primary_adv_interval_min: ExtDuration<625>,
+                primary_adv_interval_max: ExtDuration<625>,
+                primary_adv_channel_map: AdvChannelMap,
+                own_addr_kind: AddrKind,
+                peer_addr_kind: AddrKind,
+                peer_addr: BdAddr,
+                adv_filter_policy: AdvFilterPolicy,
+                adv_tx_power: i8,
+                primary_adv_phy: PhyKind,
+                secondary_adv_max_skip: u8,
+                secondary_adv_phy: PhyKind,
+                adv_sid: u8,
+                scan_request_notification_enable: bool,
+                primary_adv_phy_options: AdvPhyOptions,
+                secondary_adv_phy_options: AdvPhyOptions,
         }
         Return = i8;
     }

--- a/src/param/le.rs
+++ b/src/param/le.rs
@@ -169,6 +169,37 @@ impl<'de> FromHciBytes<'de> for &'de PhyOptions {
     }
 }
 
+/// PHY preference or requirement during extended advertisement (BLE5.4)
+#[derive(Default)]
+#[repr(u16, align(1))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[allow(missing_docs)]
+pub enum AdvPhyOptions {
+    #[default]
+    NoPreferredCoding = 0,
+    S2CodingPreferred = 1,
+    S8CodingPreferred = 2,
+    S2CodingRequired = 3,
+    S8CodingRequired = 4,
+}
+
+unsafe impl FixedSizeValue for AdvPhyOptions {
+    #[inline(always)]
+    fn is_valid(data: &[u8]) -> bool {
+        data[0] == 0 || data[0] == 1 || data[0] == 2 || data[0] == 3 || data[0] == 4
+    }
+}
+
+unsafe impl ByteAlignedValue for AdvPhyOptions {}
+
+impl<'de> FromHciBytes<'de> for &'de AdvPhyOptions {
+    #[inline(always)]
+    fn from_hci_bytes(data: &'de [u8]) -> Result<(Self, &'de [u8]), FromHciBytesError> {
+        <AdvPhyOptions as ByteAlignedValue>::ref_from_hci_bytes(data)
+    }
+}
+
 param! {
     struct ScanningPhy {
         active_scan: bool,


### PR DESCRIPTION
This PR adds `LeSetExtAdvParamsV2` from BLE5.4 which enables the specification of PHY coding preferences or requirements within extended advertisements on supported hardware.