### PR TITLE
Fix incorrect remaining bytes

### DIFF
--- a/src/cmd/controller_baseband.rs
+++ b/src/cmd/controller_baseband.rs
@@ -2,8 +2,8 @@
 
 use crate::cmd;
 use crate::param::{
-    ConnHandle, ConnHandleCompletedPackets, ControllerToHostFlowControl, Duration, EventMask, EventMaskPage2,
-    PowerLevelKind, ReadStoredLinkKeyParams, ReadStoredLinkKeyReturn,
+    BdAddr, ConnHandle, ConnHandleCompletedPackets, ControllerToHostFlowControl, Duration, EventMask, EventMaskPage2,
+    PowerLevelKind, Status,
 };
 
 cmd! {
@@ -100,11 +100,16 @@ cmd! {
     /// Read Stored Link Key command [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-9c3e0da9-138b-7641-6e84-d2d17c1f082e)
     ///
     /// Reads stored link keys for one or more devices, or all devices.
-    ///
-    /// * `bd_addr`: Bluetooth device address to read the key for, or all devices if set to all 0xFF.
-    /// * `read_all_flag`: 0x00 = read for specified device, 0x01 = read for all devices.
     ReadStoredLinkKey(CONTROL_BASEBAND, 0x000d) {
-        Params = ReadStoredLinkKeyParams;
-        Return = ReadStoredLinkKeyReturn;
+        ReadStoredLinkKeyParams {
+            bd_addr: BdAddr,
+            read_all: bool,
+        }
+        ReadStoredLinkKeyReturn {
+            status: Status,
+            max_num_keys: u8,
+            num_keys_read: u8,
+        }
+
     }
 }

--- a/src/cmd/link_control.rs
+++ b/src/cmd/link_control.rs
@@ -1,7 +1,10 @@
 //! Link Control commands [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-fe2a33d3-28f4-9fd1-4d08-62286985c05e)
 
 use crate::cmd;
-use crate::param::{BdAddr, ConnHandle, DisconnectReason};
+use crate::param::{
+    AllowRoleSwitch, BdAddr, ClockOffset, ConnHandle, DisconnectReason, PacketType, PageScanRepetitionMode, Status,
+    StatusBdAddrReturn,
+};
 
 cmd! {
     /// Inquiry command [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-2db7bf11-f361-99bd-6161-dc9696f86c6b)
@@ -12,6 +15,16 @@ cmd! {
             num_responses: u8,
         }
         Return = ();
+    }
+}
+
+cmd! {
+    /// Inquiry Cancel command [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-75fbb334-4adc-d07a-bd5c-80b85f6e7074)
+    ///
+    /// Stops the current Inquiry if the BR/EDR Controller is in Inquiry Mode.
+    InquiryCancel(LINK_CONTROL, 0x0002) {
+        Params = ();
+        Return = Status;
     }
 }
 
@@ -40,9 +53,9 @@ cmd! {
     RemoteNameRequest(LINK_CONTROL, 0x0019) {
         RemoteNameRequestParams {
             bd_addr: BdAddr,
-            page_scan_repetition_mode: u8,
-            reserved: u8,
-            clock_offset: u16,
+            page_scan_repetition_mode: PageScanRepetitionMode,
+            reserved: u8, // Reserved, shall be set to 0x00.
+            clock_offset: ClockOffset,
         }
         Return = ();
     }
@@ -55,11 +68,11 @@ cmd! {
     CreateConnection(LINK_CONTROL, 0x0005) {
         CreateConnectionParams {
             bd_addr: BdAddr,
-            packet_type: u16,
-            page_scan_repetition_mode: u8,
-            reserved: u8,
-            clock_offset: u16,
-            allow_role_switch: u8,
+            packet_type: PacketType,
+            page_scan_repetition_mode: PageScanRepetitionMode,
+            reserved: u8, // Reserved, shall be set to 0x00.
+            clock_offset: ClockOffset,
+            allow_role_switch: AllowRoleSwitch,
         }
         Return = ();
     }
@@ -95,6 +108,108 @@ cmd! {
             pin_code_len: u8,
             pin_code: [u8; 16],
         }
-        Return = BdAddr;
+        Return = StatusBdAddrReturn;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cmd::{Cmd, OpcodeGroup};
+    use crate::param::{
+        AllowRoleSwitch, BdAddr, ClockOffset, ConnHandle, DisconnectReason, PacketType, PageScanRepetitionMode,
+    };
+
+    #[test]
+    fn test_inquiry() {
+        let _cmd = Inquiry::new(
+            [0x9e, 0x8b, 0x33], // General/Unlimited Inquiry Access Code
+            0x08,               // 10.24 seconds
+            0x00,               // Unlimited number of responses
+        );
+
+        assert_eq!(Inquiry::OPCODE.group(), OpcodeGroup::new(0x01));
+        assert_eq!(Inquiry::OPCODE.cmd(), 0x0001);
+    }
+
+    #[test]
+    fn test_inquiry_cancel() {
+        let _cmd = InquiryCancel::new();
+        assert_eq!(InquiryCancel::OPCODE.group(), OpcodeGroup::new(0x01));
+        assert_eq!(InquiryCancel::OPCODE.cmd(), 0x0002);
+    }
+
+    #[test]
+    fn test_disconnect() {
+        let _cmd = Disconnect::new(ConnHandle::new(0x0001), DisconnectReason::AuthenticationFailure);
+
+        assert_eq!(Disconnect::OPCODE.group(), OpcodeGroup::new(0x01));
+        assert_eq!(Disconnect::OPCODE.cmd(), 0x0006);
+    }
+
+    #[test]
+    fn test_read_remote_version_information() {
+        let _cmd = ReadRemoteVersionInformation::new(ConnHandle::new(0x0001));
+
+        assert_eq!(ReadRemoteVersionInformation::OPCODE.group(), OpcodeGroup::new(0x01));
+        assert_eq!(ReadRemoteVersionInformation::OPCODE.cmd(), 0x001d);
+    }
+
+    #[test]
+    fn test_remote_name_request() {
+        let _cmd = RemoteNameRequest::new(
+            BdAddr::new([0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc]),
+            PageScanRepetitionMode::R2,
+            0x00, // reserved
+            ClockOffset::new().set_clock_offset_0(true),
+        );
+        assert_eq!(RemoteNameRequest::OPCODE.group(), OpcodeGroup::new(0x01));
+        assert_eq!(RemoteNameRequest::OPCODE.cmd(), 0x0019);
+    }
+
+    #[test]
+    fn test_create_connection() {
+        let _cmd = CreateConnection::new(
+            BdAddr::new([0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc]),
+            PacketType::new()
+                .set_dh1_may_be_used(true)
+                .set_dm3_may_be_used(true)
+                .set_dh3_may_be_used(true),
+            PageScanRepetitionMode::R2,
+            0x00, // reserved
+            ClockOffset::new(),
+            AllowRoleSwitch::Allowed,
+        );
+        assert_eq!(CreateConnection::OPCODE.group(), OpcodeGroup::new(0x01));
+        assert_eq!(CreateConnection::OPCODE.cmd(), 0x0005);
+    }
+
+    #[test]
+    fn test_authentication_requested() {
+        let _cmd = AuthenticationRequested::new(ConnHandle::new(0x0001));
+
+        assert_eq!(AuthenticationRequested::OPCODE.group(), OpcodeGroup::new(0x01));
+        assert_eq!(AuthenticationRequested::OPCODE.cmd(), 0x0011);
+    }
+
+    #[test]
+    fn test_link_key_request_negative_reply() {
+        let bd_addr = BdAddr::new([0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc]);
+        let _cmd = LinkKeyRequestNegativeReply::new(bd_addr);
+
+        assert_eq!(LinkKeyRequestNegativeReply::OPCODE.group(), OpcodeGroup::new(0x01));
+        assert_eq!(LinkKeyRequestNegativeReply::OPCODE.cmd(), 0x000c);
+    }
+
+    #[test]
+    fn test_pin_code_request_reply() {
+        let _cmd = PinCodeRequestReply::new(
+            BdAddr::new([0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc]),
+            4,
+            [b'1', b'2', b'3', b'4', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        );
+
+        assert_eq!(PinCodeRequestReply::OPCODE.group(), OpcodeGroup::new(0x01));
+        assert_eq!(PinCodeRequestReply::OPCODE.cmd(), 0x000d);
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -5,7 +5,7 @@ use crate::param::{
     param, BdAddr, ClockOffset, ConnHandle, ConnHandleCompletedPackets, ConnectionLinkType, CoreSpecificationVersion,
     Error, LinkKeyType, LinkType, LmpFeatureMask, PageScanRepetitionMode, RemainingBytes, Status,
 };
-use crate::{FromHciBytes, FromHciBytesError, ReadHci, ReadHciError};
+use crate::{AsHciBytes, FromHciBytes, FromHciBytesError, ReadHci, ReadHciError};
 
 pub mod le;
 
@@ -353,5 +353,245 @@ impl CommandComplete<'_> {
                 Err(FromHciBytesError::InvalidSize)
             }
         })
+    }
+}
+
+/// Struct representing a single parsed inquiry result item
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InquiryResultItem {
+    /// Bluetooth Device Address (BD_ADDR) of the device found
+    pub bd_addr: BdAddr,
+    /// Page scan repetition mode of the device
+    pub page_scan_repetition_mode: Option<PageScanRepetitionMode>,
+    /// Class of device (CoD) of the device found
+    pub class_of_device: Option<[u8; 3]>,
+    /// Clock offset of the device found
+    pub clock_offset: Option<ClockOffset>,
+    /// Received Signal Strength Indicator (RSSI) of the device found
+    /// This field is only present in `InquiryResultWithRssi`
+    pub rssi: Option<i8>,
+}
+
+/// Iterator over inquiry result items
+pub struct InquiryResultIter<'a> {
+    bytes: &'a [u8],
+    num_responses: usize,
+    idx: usize,
+    kind: InquiryResultKind,
+}
+
+/// Kind of inquiry result, indicating whether it includes RSSI or not
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum InquiryResultKind {
+    /// Standard inquiry result without RSSI
+    Standard,
+    /// Inquiry result with RSSI
+    WithRssi,
+}
+
+impl<'a> InquiryResultIter<'a> {
+    /// Creates a new iterator for standard inquiry results
+    pub fn new_standard(bytes: &'a [u8], num_responses: usize) -> Self {
+        InquiryResultIter {
+            bytes,
+            num_responses,
+            idx: 0,
+            kind: InquiryResultKind::Standard,
+        }
+    }
+
+    /// Creates a new iterator for inquiry results with RSSI
+    pub fn new_with_rssi(bytes: &'a [u8], num_responses: usize) -> Self {
+        InquiryResultIter {
+            bytes,
+            num_responses,
+            idx: 0,
+            kind: InquiryResultKind::WithRssi,
+        }
+    }
+}
+
+impl Iterator for InquiryResultIter<'_> {
+    type Item = InquiryResultItem;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.idx >= self.num_responses {
+            return None;
+        }
+
+        let i = self.idx;
+        let n = self.num_responses;
+
+        let bd_addr_size = n * 6;
+        let page_scan_size = n;
+        let class_size = n * 3;
+        let clock_size = n * 2;
+
+        let reserved_size = match self.kind {
+            InquiryResultKind::Standard => n * 2,
+            InquiryResultKind::WithRssi => n,
+        };
+
+        let bd_addr_off = i * 6;
+        let page_scan_off = bd_addr_size + i;
+        let class_off = bd_addr_size + page_scan_size + reserved_size + i * 3;
+        let clock_off = bd_addr_size + page_scan_size + reserved_size + class_size + i * 2;
+
+        if self.bytes.len() < bd_addr_off + 6 {
+            return None;
+        }
+
+        let bd_addr = BdAddr::new([
+            self.bytes[bd_addr_off],
+            self.bytes[bd_addr_off + 1],
+            self.bytes[bd_addr_off + 2],
+            self.bytes[bd_addr_off + 3],
+            self.bytes[bd_addr_off + 4],
+            self.bytes[bd_addr_off + 5],
+        ]);
+
+        let page_scan_repetition_mode = self
+            .bytes
+            .get(page_scan_off)
+            .and_then(|b| PageScanRepetitionMode::from_hci_bytes(&[*b]).ok().map(|(m, _)| m));
+
+        let class_of_device = self.bytes.get(class_off..class_off + 3).map(|s| [s[0], s[1], s[2]]);
+
+        let clock_offset = self
+            .bytes
+            .get(clock_off..clock_off + 2)
+            .and_then(|s| ClockOffset::from_hci_bytes(s).ok().map(|(c, _)| c));
+
+        let rssi = if self.kind == InquiryResultKind::WithRssi {
+            let rssi_off = bd_addr_size + page_scan_size + reserved_size + class_size + clock_size + i;
+            self.bytes.get(rssi_off).map(|b| *b as i8)
+        } else {
+            None
+        };
+
+        self.idx += 1;
+
+        Some(InquiryResultItem {
+            bd_addr,
+            page_scan_repetition_mode,
+            class_of_device,
+            clock_offset,
+            rssi,
+        })
+    }
+}
+
+/// Inquiry result event containing multiple responses
+impl InquiryResult<'_> {
+    /// Returns an iterator over all valid inquiry result items.
+    pub fn iter(&self) -> InquiryResultIter {
+        let bytes = self.bytes.as_hci_bytes();
+        let n = self.num_responses as usize;
+        InquiryResultIter::new_standard(bytes, n)
+    }
+}
+
+/// Inquiry result event containing multiple responses with RSSI
+impl InquiryResultWithRssi<'_> {
+    /// Returns an iterator over all valid inquiry result items.
+    pub fn iter(&self) -> InquiryResultIter {
+        let bytes = self.bytes.as_hci_bytes();
+        let n = self.num_responses as usize;
+        InquiryResultIter::new_with_rssi(bytes, n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::param::PageScanRepetitionMode;
+
+    #[test]
+    fn test_inquiry_result() {
+        let data = [
+            0x02, // num_responses = 2
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, // addr 1
+            0x11, 0x12, 0x13, 0x14, 0x15, 0x16, // addr 2
+            0x01, 0x02, // R1, R2
+            0x00, 0x00, 0x00, 0x00, // reserved
+            0x20, 0x04, 0x00, 0x30, 0x05, 0x01, // class of device
+            0x34, 0x12, 0x78, 0x56, // clock offsets
+        ];
+        let (inquiry_result, _) = InquiryResult::from_hci_bytes(&data).unwrap();
+
+        let mut iter = inquiry_result.iter();
+
+        let item1 = iter.next().unwrap();
+        assert_eq!(item1.bd_addr.as_hci_bytes(), &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+        assert_eq!(item1.page_scan_repetition_mode, Some(PageScanRepetitionMode::R1));
+        assert_eq!(item1.class_of_device, Some([0x20, 0x04, 0x00]));
+        assert_eq!(item1.clock_offset.unwrap().as_hci_bytes(), &[0x34, 0x12]);
+        assert_eq!(item1.rssi, None);
+
+        let item2 = iter.next().unwrap();
+        assert_eq!(item2.bd_addr.as_hci_bytes(), &[0x11, 0x12, 0x13, 0x14, 0x15, 0x16]);
+        assert_eq!(item2.page_scan_repetition_mode, Some(PageScanRepetitionMode::R2));
+        assert_eq!(item2.class_of_device, Some([0x30, 0x05, 0x01]));
+        assert_eq!(item2.clock_offset.unwrap().as_hci_bytes(), &[0x78, 0x56]);
+        assert_eq!(item2.rssi, None);
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_inquiry_result_with_rssi() {
+        let data = [
+            0x02, // num_responses = 2
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, // addr 1
+            0x11, 0x12, 0x13, 0x14, 0x15, 0x16, // addr 2
+            0x01, 0x02, // R1, R2
+            0x00, 0x00, // reserved
+            0x20, 0x04, 0x00, 0x30, 0x05, 0x01, // class of device
+            0x34, 0x12, 0x78, 0x56, // clock offsets
+            0xF0, 0xE8, // RSSI
+        ];
+        let (inquiry_result, _) = InquiryResultWithRssi::from_hci_bytes(&data).unwrap();
+
+        let mut iter = inquiry_result.iter();
+
+        let item1 = iter.next().unwrap();
+        assert_eq!(item1.bd_addr.as_hci_bytes(), &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+        assert_eq!(item1.page_scan_repetition_mode, Some(PageScanRepetitionMode::R1));
+        assert_eq!(item1.class_of_device, Some([0x20, 0x04, 0x00]));
+        assert_eq!(item1.clock_offset.unwrap().as_hci_bytes(), &[0x34, 0x12]);
+        assert_eq!(item1.rssi, Some(-16));
+
+        let item2 = iter.next().unwrap();
+        assert_eq!(item2.bd_addr.as_hci_bytes(), &[0x11, 0x12, 0x13, 0x14, 0x15, 0x16]);
+        assert_eq!(item2.page_scan_repetition_mode, Some(PageScanRepetitionMode::R2));
+        assert_eq!(item2.class_of_device, Some([0x30, 0x05, 0x01]));
+        assert_eq!(item2.clock_offset.unwrap().as_hci_bytes(), &[0x78, 0x56]);
+        assert_eq!(item2.rssi, Some(-24));
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_extended_inquiry_result() {
+        let data = [
+            0x01, // num_responses = 1
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, // bd_addr
+            0x01, // page_scan_repetition_mode (R1)
+            0x00, // reserved
+            0x20, 0x04, 0x00, // class_of_device
+            0x34, 0x12, // clock_offset
+            0xF0, // rssi (-16)
+            0x09, 0x08, 0x54, 0x65, 0x73, 0x74, 0x20, 0x44, 0x65, 0x76, // eir_data (sample EIR data)
+        ];
+        let (eir_result, _) = ExtendedInquiryResult::from_hci_bytes(&data).unwrap();
+
+        assert_eq!(eir_result.num_responses, 1);
+        assert_eq!(eir_result.bd_addr.as_hci_bytes(), &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+        assert_eq!(eir_result.page_scan_repetition_mode, PageScanRepetitionMode::R1);
+        assert_eq!(eir_result.reserved, 0x00);
+        assert_eq!(eir_result.class_of_device, [0x20, 0x04, 0x00]);
+        assert_eq!(eir_result.clock_offset.as_hci_bytes(), &[0x34, 0x12]);
+        assert_eq!(eir_result.rssi, -16);
+        assert_eq!(
+            eir_result.eir_data.as_hci_bytes(),
+            &[0x09, 0x08, 0x54, 0x65, 0x73, 0x74, 0x20, 0x44, 0x65, 0x76]
+        );
     }
 }

--- a/src/param.rs
+++ b/src/param.rs
@@ -2,6 +2,7 @@
 
 use crate::{AsHciBytes, ByteAlignedValue, FixedSizeValue, FromHciBytes, FromHciBytesError, WriteHci};
 
+mod classic;
 mod cmd_mask;
 mod event_masks;
 mod feature_masks;
@@ -10,6 +11,7 @@ mod macros;
 mod primitives;
 mod status;
 
+pub use classic::*;
 pub use cmd_mask::*;
 pub use event_masks::*;
 pub use feature_masks::*;
@@ -330,53 +332,6 @@ impl ConnHandleCompletedPackets {
         handle.write_hci(&mut dest[0..2]).unwrap();
         num_completed_packets.write_hci(&mut dest[2..4]).unwrap();
         Self(dest)
-    }
-}
-
-param! {
-    /// Parameters for Read Stored Link Key command
-    struct ReadStoredLinkKeyParams {
-        bd_addr: BdAddr,
-        read_all_flag: u8,
-    }
-}
-
-param! {
-    /// Return parameters for Read Stored Link Key command
-    struct ReadStoredLinkKeyReturn {
-        max_num_keys: u8,
-        num_keys_read: u8,
-    }
-}
-
-param! {
-    /// Parameters for Remote Name Request command
-    struct RemoteNameRequestParams {
-        bd_addr: BdAddr,
-        page_scan_repetition_mode: u8,
-        reserved: u8,
-        clock_offset: u16,
-    }
-}
-
-param! {
-    /// Parameters for Create Connection command
-    struct CreateConnectionParams {
-        bd_addr: BdAddr,
-        packet_type: u16,
-        page_scan_repetition_mode: u8,
-        reserved: u8,
-        clock_offset: u16,
-        allow_role_switch: u8,
-    }
-}
-
-param! {
-    /// Parameters for Pin Code Request Reply command
-    struct PinCodeRequestReplyParams {
-        bd_addr: BdAddr,
-        pin_code_len: u8,
-        pin_code: [u8; 16],
     }
 }
 

--- a/src/param/classic.rs
+++ b/src/param/classic.rs
@@ -1,0 +1,112 @@
+use crate::param::macros::param;
+use crate::param::{BdAddr, Status};
+
+param! {
+    bitfield PacketType[2] {
+        // ACL Link_Type bits
+        (1, shall_not_be_used_2dh1, set_shall_not_be_used_2dh1);
+        (2, shall_not_be_used_3dh1, set_shall_not_be_used_3dh1);
+        // Bit 3: Ignored; DM1 may be used whether or not this bit is set
+        (4, dh1_may_be_used, set_dh1_may_be_used);
+        // SCO Link_Type bits
+        (5, hv1_may_be_used, set_hv1_may_be_used);
+        (6, hv2_may_be_used, set_hv2_may_be_used);
+        (7, hv3_may_be_used, set_hv3_may_be_used);
+        // ACL Link_Type bits (continued)
+        (8, shall_not_be_used_2dh3, set_shall_not_be_used_2dh3);
+        (9, shall_not_be_used_3dh3, set_shall_not_be_used_3dh3);
+        (10, dm3_may_be_used, set_dm3_may_be_used);
+        (11, dh3_may_be_used, set_dh3_may_be_used);
+        (12, shall_not_be_used_2dh5, set_shall_not_be_used_2dh5);
+        (13, shall_not_be_used_3dh5, set_shall_not_be_used_3dh5);
+        (14, dm5_may_be_used, set_dm5_may_be_used);
+        (15, dh5_may_be_used, set_dh5_may_be_used);
+    }
+}
+
+param! {
+    bitfield ClockOffset[2] {
+        // Bits 0-14: Bits 2 to 16 of CLKNPeripheral - CLK
+        (0, clock_offset_0, set_clock_offset_0);
+        (1, clock_offset_1, set_clock_offset_1);
+        (2, clock_offset_2, set_clock_offset_2);
+        (3, clock_offset_3, set_clock_offset_3);
+        (4, clock_offset_4, set_clock_offset_4);
+        (5, clock_offset_5, set_clock_offset_5);
+        (6, clock_offset_6, set_clock_offset_6);
+        (7, clock_offset_7, set_clock_offset_7);
+        (8, clock_offset_8, set_clock_offset_8);
+        (9, clock_offset_9, set_clock_offset_9);
+        (10, clock_offset_10, set_clock_offset_10);
+        (11, clock_offset_11, set_clock_offset_11);
+        (12, clock_offset_12, set_clock_offset_12);
+        (13, clock_offset_13, set_clock_offset_13);
+        (14, clock_offset_14, set_clock_offset_14);
+        // Bit 15: Clock_Offset_Valid_Flag (0 = Invalid, 1 = Valid)
+        (15, clock_offset_valid_flag, set_clock_offset_valid_flag);
+    }
+}
+
+param! {
+    enum PageScanRepetitionMode{
+        /// Page scan repetition mode 0
+        R0 = 0x00,
+        /// Page scan repetition mode 1
+        R1 = 0x01,
+        /// Page scan repetition mode 2
+        R2 = 0x02,
+        // Reserved for future use
+    }
+}
+
+param! {
+    enum AllowRoleSwitch{
+        /// The local device will be a Central, and will not accept a role switch requested by
+        /// the remote device at the connection setup.
+        NotAllowed = 0x00,
+        /// The local device may be a Central, or may become a Peripheral after accepting a role switch
+        /// requested by the remote device at the connection setup.
+        Allowed = 0x01,
+        // Reserved for future use
+    }
+}
+
+param! {
+    enum ConnectionLinkType {
+        /// SCO connection
+        Sco = 0x00,
+        /// ACL connection (Data Channels)
+        Acl = 0x01,
+        /// eSCO connection (Enhanced Data Channels)
+        EnhancedSco = 0x02,
+        // All other values reserved for future use
+    }
+}
+
+param! {
+    enum LinkKeyType {
+        /// Combination Key
+        CombinationKey = 0x00,
+        /// Debug Combination Key
+        DebugCombinationKey = 0x03,
+        /// Unauthenticated Combination Key generated from P-192
+        UnauthenticatedCombinationKeyP192 = 0x04,
+        /// Authenticated Combination Key generated from P-192
+        AuthenticatedCombinationKeyP192 = 0x05,
+        /// Changed Combination Key
+        ChangedCombinationKey = 0x06,
+        /// Unauthenticated Combination Key generated from P-256
+        UnauthenticatedCombinationKeyP256 = 0x07,
+        /// Authenticated Combination Key generated from P-256
+        AuthenticatedCombinationKeyP256 = 0x08,
+        // All other values reserved for future use
+    }
+}
+
+param! {
+    /// Common return parameters for commands that return a status and a Bluetooth device address
+    struct StatusBdAddrReturn {
+        status: Status,
+        bd_addr: BdAddr,
+    }
+}


### PR DESCRIPTION
Hi maintainers,

I realized I was using `RemainingBytes` incorrectly. Please review this fix. Since this affects the `InquiryResult` and `InquiryResultWithRssi` events, I implemented an iterator for efficient parsing.

Since I use this crate extensively in my projects, if you'd like, I plan to complete the commands and events, at least for classic Bluetooth (BR/EDR). Wdyt?