### PR TITLE
Add missing link controls commands from 0x01 - 0x0f

### DIFF
--- a/src/cmd/link_control.rs
+++ b/src/cmd/link_control.rs
@@ -6,6 +6,8 @@ use crate::param::{
     OobDataPresent, PacketType, PageScanRepetitionMode, Status,
 };
 
+// 0x0001 - 0x000F
+
 cmd! {
     /// Inquiry command [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-2db7bf11-f361-99bd-6161-dc9696f86c6b)
     Inquiry(LINK_CONTROL, 0x0001) {
@@ -29,39 +31,6 @@ cmd! {
 }
 
 cmd! {
-    /// Disconnect command [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-6bb8119e-aa67-d517-db2a-7470c35fbf4a)
-    Disconnect(LINK_CONTROL, 0x0006) {
-        DisconnectParams {
-            handle: ConnHandle,
-            reason: DisconnectReason,
-        }
-        Return = ();
-    }
-}
-
-cmd! {
-    /// Read Remote Version Information command [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-ebf3c9ac-0bfa-0ed0-c014-8f8691ea3fe5)
-    ReadRemoteVersionInformation(LINK_CONTROL, 0x001d) {
-        Params = ConnHandle;
-    }
-}
-
-cmd! {
-    /// Remote Name Request command [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-cbd9cb09-59fd-9739-2570-8fae93d45bd7)
-    ///
-    /// Initiates a remote name request procedure for the specified Bluetooth device.
-    RemoteNameRequest(LINK_CONTROL, 0x0019) {
-        RemoteNameRequestParams {
-            bd_addr: BdAddr,
-            page_scan_repetition_mode: PageScanRepetitionMode,
-            reserved: u8, // Reserved, shall be set to 0x00.
-            clock_offset: ClockOffset,
-        }
-        Return = ();
-    }
-}
-
-cmd! {
     /// Create Connection command [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-4150eaa8-3d28-1113-68cf-5bae5bae78fd)
     ///
     /// Initiates a connection to a remote Bluetooth device.
@@ -79,23 +48,11 @@ cmd! {
 }
 
 cmd! {
-    /// Authentication Requested command [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-904095aa-072e-02c1-023a-e16571079cd2)
-    ///
-    /// Initiates authentication (pairing) for the given connection handle.
-    AuthenticationRequested(LINK_CONTROL, 0x0011) {
-        Params = ConnHandle;
-        Return = ();
-    }
-}
-
-cmd! {
-    /// Set Connection Encryption command [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-0dd32c20-9eda-0ee0-b15f-cf896c9a1df5)
-    ///
-    /// Used to enable or disable encryption on a connection after authentication.
-    SetConnectionEncryption(LINK_CONTROL, 0x0013) {
-        SetConnectionEncryptionParams {
+    /// Disconnect command [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-6bb8119e-aa67-d517-db2a-7470c35fbf4a)
+    Disconnect(LINK_CONTROL, 0x0006) {
+        DisconnectParams {
             handle: ConnHandle,
-            encryption_enable: bool,
+            reason: DisconnectReason,
         }
         Return = ();
     }
@@ -137,6 +94,55 @@ cmd! {
         Return = BdAddr;
     }
 }
+
+// 0x0011 - 0x001F
+
+cmd! {
+    /// Authentication Requested command [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-904095aa-072e-02c1-023a-e16571079cd2)
+    ///
+    /// Initiates authentication (pairing) for the given connection handle.
+    AuthenticationRequested(LINK_CONTROL, 0x0011) {
+        Params = ConnHandle;
+        Return = ();
+    }
+}
+
+cmd! {
+    /// Set Connection Encryption command [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-0dd32c20-9eda-0ee0-b15f-cf896c9a1df5)
+    ///
+    /// Used to enable or disable encryption on a connection after authentication.
+    SetConnectionEncryption(LINK_CONTROL, 0x0013) {
+        SetConnectionEncryptionParams {
+            handle: ConnHandle,
+            encryption_enable: bool,
+        }
+        Return = ();
+    }
+}
+
+cmd! {
+    /// Remote Name Request command [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-cbd9cb09-59fd-9739-2570-8fae93d45bd7)
+    ///
+    /// Initiates a remote name request procedure for the specified Bluetooth device.
+    RemoteNameRequest(LINK_CONTROL, 0x0019) {
+        RemoteNameRequestParams {
+            bd_addr: BdAddr,
+            page_scan_repetition_mode: PageScanRepetitionMode,
+            reserved: u8, // Reserved, shall be set to 0x00.
+            clock_offset: ClockOffset,
+        }
+        Return = ();
+    }
+}
+
+cmd! {
+    /// Read Remote Version Information command [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-ebf3c9ac-0bfa-0ed0-c014-8f8691ea3fe5)
+    ReadRemoteVersionInformation(LINK_CONTROL, 0x001d) {
+        Params = ConnHandle;
+    }
+}
+
+// 0x0020 - 0x002F
 
 cmd! {
     /// IO Capability Request Reply command [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-063323a1-51b0-a373-8e29-84f9d0e0263e)

--- a/src/cmd/link_control.rs
+++ b/src/cmd/link_control.rs
@@ -3,7 +3,6 @@
 use crate::cmd;
 use crate::param::{
     AllowRoleSwitch, BdAddr, ClockOffset, ConnHandle, DisconnectReason, PacketType, PageScanRepetitionMode, Status,
-    StatusBdAddrReturn,
 };
 
 cmd! {
@@ -108,7 +107,7 @@ cmd! {
             pin_code_len: u8,
             pin_code: [u8; 16],
         }
-        Return = StatusBdAddrReturn;
+        Return = BdAddr;
     }
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -209,6 +209,20 @@ events! {
         handle: ConnHandle,
     }
 
+
+
+    /// IO Capability Request event [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-343681e1-ca08-8d4c-79c3-e4b2c86ecba1)
+    struct IoCapabilityRequest(0x31) {
+        bd_addr: BdAddr,
+    }
+
+
+    /// User Confirmation Request event [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-e7014a9e-718f-6aa8-d657-35b547e9c5d6)
+    struct UserConfirmationRequest(0x33) {
+        bd_addr: BdAddr,
+        numeric_value: u32,
+    }
+
     /// Authenticated Payload Timeout Expired event [📖](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-6cfdff94-ace8-294c-6af9-d90d94653e19)
     struct AuthenticatedPayloadTimeoutExpired(0x57) {
         handle: ConnHandle,
@@ -592,5 +606,22 @@ mod tests {
             eir_result.eir_data.as_hci_bytes(),
             &[0x09, 0x08, 0x54, 0x65, 0x73, 0x74, 0x20, 0x44, 0x65, 0x76]
         );
+    }
+
+    #[test]
+    fn test_io_capability_request() {
+        let data = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
+        let (evt, rest) = IoCapabilityRequest::from_hci_bytes(&data).unwrap();
+        assert_eq!(evt.bd_addr.raw(), [1, 2, 3, 4, 5, 6]);
+        assert!(rest.is_empty());
+    }
+
+    #[test]
+    fn test_user_confirmation_request() {
+        let data = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x78, 0x56, 0x34, 0x12];
+        let (evt, rest) = UserConfirmationRequest::from_hci_bytes(&data).unwrap();
+        assert_eq!(evt.bd_addr.raw(), [1, 2, 3, 4, 5, 6]);
+        assert_eq!(evt.numeric_value, 0x1234_5678);
+        assert!(rest.is_empty());
     }
 }

--- a/src/param/classic.rs
+++ b/src/param/classic.rs
@@ -147,3 +147,23 @@ param! {
         // All other values reserved for future use
     }
 }
+
+param! {
+    enum Role {
+        /// Become the Central for this connection. The LM will perform the role switch.
+        Central = 0x00,
+        /// Remain the Peripheral for this connection. The LM will NOT perform the role switch.
+        Peripheral = 0x01,
+    }
+}
+
+param! {
+    enum RejectReason {
+        /// Connection Rejected due to Limited Resources
+        LimitedResources = 0x0D,
+        /// Connection Rejected Due To Security Reasons
+        SecurityReasons = 0x0E,
+        /// Connection Rejected due to Unacceptable BD_ADDR
+        UnacceptableBdAddr = 0x0F,
+    }
+}

--- a/src/param/classic.rs
+++ b/src/param/classic.rs
@@ -1,5 +1,4 @@
 use crate::param::macros::param;
-use crate::param::{BdAddr, Status};
 
 param! {
     bitfield PacketType[2] {
@@ -100,13 +99,5 @@ param! {
         /// Authenticated Combination Key generated from P-256
         AuthenticatedCombinationKeyP256 = 0x08,
         // All other values reserved for future use
-    }
-}
-
-param! {
-    /// Common return parameters for commands that return a status and a Bluetooth device address
-    struct StatusBdAddrReturn {
-        status: Status,
-        bd_addr: BdAddr,
     }
 }

--- a/src/param/classic.rs
+++ b/src/param/classic.rs
@@ -101,3 +101,49 @@ param! {
         // All other values reserved for future use
     }
 }
+
+param! {
+    enum IoCapability{
+        /// Display Only
+        DisplayOnly = 0x00,
+        /// Display Yes/No
+        DisplayYesNo = 0x01,
+        /// Keyboard Only
+        KeyboardOnly = 0x02,
+        /// No Input No Output
+        NoInputNoOutput = 0x03,
+        // All other values reserved for future use
+    }
+}
+
+param! {
+    enum OobDataPresent {
+        /// OOB authentication data not present
+        NotPresent = 0x00,
+        /// P-192 OOB authentication data from remote device present
+        P192Present = 0x01,
+        /// P-256 OOB authentication data from remote device present
+        P256Present = 0x02,
+        /// P-192 and P-256 OOB authentication data from remote device present
+        P192AndP256Present = 0x03,
+        // All other values reserved for future use
+    }
+}
+
+param! {
+    enum AuthenticationRequirements {
+        /// MITM Protection Not Required – No Bonding. Numeric comparison with automatic accept allowed.
+        MitmNotRequiredNoBonding = 0x00,
+        /// MITM Protection Required – No Bonding. Use IO Capabilities to determine authentication procedure
+        MitmRequiredNoBonding = 0x01,
+        /// MITM Protection Not Required – Dedicated Bonding. Numeric comparison with automatic accept allowed.
+        MitmNotRequiredDedicatedBonding = 0x02,
+        /// MITM Protection Required – Dedicated Bonding. Use IO Capabilities to determine authentication procedure
+        MitmRequiredDedicatedBonding = 0x03,
+        /// MITM Protection Not Required – General Bonding. Numeric Comparison with automatic accept allowed.
+        MitmNotRequiredGeneralBonding = 0x04,
+        /// MITM Protection Required – General Bonding. Use IO capabilities to determine authentication procedure.
+        MitmRequiredGeneralBonding = 0x05,
+        // All other values reserved for future use
+    }
+}


### PR DESCRIPTION
Hi maintainers,

This is part of PR series to complete the bluetooth BR/EDR commands and events.

1. Fix the return command as status is already consumed.
2. Sort the commands based on OCF
3. Add missing link controls command from 0x01 - 0x0f