### PR TITLE
Bump `heapless` and `embassy-time` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
  "embedded-io",
  "embedded-io-async",
  "futures-intrusive",
- "heapless 0.8.0",
+ "heapless 0.9.1",
  "log",
  "postcard",
  "serde",
@@ -141,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-time"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f820157f198ada183ad62e0a66f554c610cdcd1a9f27d4b316358103ced7a1f8"
+checksum = "f4fa65b9284d974dad7a23bb72835c4ec85c0b540d86af7fc4098c88cff51d65"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -152,14 +152,14 @@ dependencies = [
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
- "futures-util",
+ "futures-core",
 ]
 
 [[package]]
 name = "embassy-time-driver"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d45f5d833b6d98bd2aab0c2de70b18bfaa10faf661a1578fd8e5dfb15eb7eba"
+checksum = "a0a244c7dc22c8d0289379c8d8830cae06bb93d8f990194d0de5efb3b5ae7ba6"
 dependencies = [
  "document-features",
 ]
@@ -285,6 +285,16 @@ name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32 0.3.1",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1edcd5a338e64688fbdcb7531a846cfd3476a54784dcb918a0844682bc7ada5"
 dependencies = [
  "hash32 0.3.1",
  "stable_deref_trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.4.0"
 documentation = "https://docs.rs/bt-hci"
 keywords = ["bluetooth", "hci", "BLE"]
 categories = ["embedded", "hardware-support", "no-std"]
-rust-version = "1.85"
+rust-version = "1.87"
 exclude = [".github", ".vscode", "ci.sh", "rust-toolchain.toml", "rustfmt.toml"]
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,15 @@ documentation = "https://docs.rs/bt-hci"
 keywords = ["bluetooth", "hci", "BLE"]
 categories = ["embedded", "hardware-support", "no-std"]
 rust-version = "1.85"
-exclude = [
-    ".github",
-    ".vscode",
-    "ci.sh",
-    "rust-toolchain.toml",
-    "rustfmt.toml",
-]
+exclude = [".github", ".vscode", "ci.sh", "rust-toolchain.toml", "rustfmt.toml"]
 
 [features]
-defmt = ["dep:defmt", "embedded-io/defmt-03", "embedded-io-async/defmt-03", "btuuid/defmt"]
+defmt = [
+    "dep:defmt",
+    "embedded-io/defmt-03",
+    "embedded-io-async/defmt-03",
+    "btuuid/defmt",
+]
 serde = ["dep:serde", "btuuid/serde"]
 uuid = ["btuuid/uuid"]
 
@@ -30,8 +29,8 @@ log = { version = "^0.4", optional = true }
 embedded-io = "0.6.0"
 embedded-io-async = "0.6.0"
 embassy-sync = "0.7"
-embassy-time = { version = ">=0.3, <0.5", optional = true }
-heapless = "0.8"
+embassy-time = { version = "0.5", optional = true }
+heapless = "0.9"
 futures-intrusive = { version = "0.5.0", default-features = false }
 serde = { version = "^1", optional = true, features = [
     "derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ log = { version = "^0.4", optional = true }
 embedded-io = "0.6.0"
 embedded-io-async = "0.6.0"
 embassy-sync = "0.7"
-embassy-time = { version = "0.5", optional = true }
-heapless = "0.9"
+embassy-time = { version = ">=0.3, <0.6", optional = true }
+heapless = ">=0.8, <0.10"
 futures-intrusive = { version = "0.5.0", default-features = false }
 serde = { version = "^1", optional = true, features = [
     "derive",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Before upgrading check that everything is available on all tier1 targets here:
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
-channel = "1.85"
+channel = "1.87"
 components = ["rust-src", "rustfmt", "llvm-tools-preview", "clippy"]
 targets = [
     "thumbv7em-none-eabi",

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -311,7 +311,7 @@ impl<const SLOTS: usize> ControllerState<SLOTS> {
                     if !data.is_empty() {
                         assert!(!event.is_null());
                         // Safety: since the slot is in pending, the caller stack will be valid.
-                        unsafe { (**event)[..data.len()].copy_from_slice(data) };
+                        unsafe { (&mut (**event))[..data.len()].copy_from_slice(data) };
                     }
                     self.signals[idx].signal(CommandResponse {
                         status,

--- a/src/event.rs
+++ b/src/event.rs
@@ -788,7 +788,7 @@ impl Iterator for InquiryResultIter<'_> {
 /// Inquiry result event containing multiple responses
 impl InquiryResult<'_> {
     /// Returns an iterator over all valid inquiry result items.
-    pub fn iter(&self) -> InquiryResultIter {
+    pub fn iter(&self) -> InquiryResultIter<'_> {
         let bytes = self.bytes.as_hci_bytes();
         let n = self.num_responses as usize;
         InquiryResultIter::new_standard(bytes, n)
@@ -798,7 +798,7 @@ impl InquiryResult<'_> {
 /// Inquiry result event containing multiple responses with RSSI
 impl InquiryResultWithRssi<'_> {
     /// Returns an iterator over all valid inquiry result items.
-    pub fn iter(&self) -> InquiryResultIter {
+    pub fn iter(&self) -> InquiryResultIter<'_> {
         let bytes = self.bytes.as_hci_bytes();
         let n = self.num_responses as usize;
         InquiryResultIter::new_with_rssi(bytes, n)


### PR DESCRIPTION
- Bump heapless and embassy-time version to latest
- Bump MSRV to 1.87
- Fix two warnings reported by the compiler